### PR TITLE
Code review: fix interpolation bugs, license, and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+build/
+*.o
+*.elf
+*.hex
+*.bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 **Author**: Michael Champagne (crimsondove)
 **Version**: 3.1.1
 **Repo**: https://github.com/TheAngryRaven/DovesLapTimer
-**License**: LICENSE file contains GPL v3 (library.properties says MIT - MISMATCH, needs resolution)
+**License**: GPL v3
 **Dependency**: ArxTypeTraits (auto-included by Arduino Library Manager)
 
 The library does NOT interface with GPS hardware directly. You feed it coordinates and time,
@@ -143,10 +143,10 @@ DovesLapTimer/
 2. **Altitude messing up distance**: `loop()` line 27 has TODO: "I think alt is messing up, investigate more... maybe flag?"
 3. **Early abort bug**: checkStartFinish line 148-149 TODO about aborting early causing re-check immediately
 4. **`checkStartFinish` portability**: Line 106 TODO to make more portable for split timing
-5. **License mismatch**: GPL v3 in LICENSE file vs MIT in library.properties
-6. **Header comment outdated**: Says "single split time" but library supports 3 sectors now
-7. **No keywords.txt**: Missing for Arduino IDE syntax highlighting
-8. **No .gitignore**: Missing
+5. ~~**License mismatch**~~: Resolved - GPL v3, library.properties updated
+6. ~~**Header comment outdated**~~: Fixed - updated to mention 3-sector timing
+7. ~~**No keywords.txt**~~: Added
+8. ~~**No .gitignore**~~: Added
 
 ## Supported Hardware
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# DovesLapTimer - Project Guide
+
+> **IMPORTANT**: Always keep this CLAUDE.md file updated when making changes to the codebase.
+> When adding new features, modifying APIs, fixing bugs, or changing architecture, update the
+> relevant sections below so future sessions don't waste tokens re-exploring the project.
+
+## Project Overview
+
+**What**: GPS-based lap timing Arduino library for go-kart / racing applications.
+**Author**: Michael Champagne (crimsondove)
+**Version**: 3.1.1
+**Repo**: https://github.com/TheAngryRaven/DovesLapTimer
+**License**: LICENSE file contains GPL v3 (library.properties says MIT - MISMATCH, needs resolution)
+**Dependency**: ArxTypeTraits (auto-included by Arduino Library Manager)
+
+The library does NOT interface with GPS hardware directly. You feed it coordinates and time,
+it handles crossing detection, lap timing, sector splits, distance tracking, and pace comparison.
+
+## Directory Structure
+
+```
+DovesLapTimer/
+├── src/
+│   ├── DovesLapTimer.h          # Header - class definition, structs, public API (535 lines)
+│   └── DovesLapTimer.cpp        # Implementation - all logic (929 lines)
+├── examples/
+│   ├── basic_oled_example/      # Full working example with OLED + uBlox GPS
+│   │   ├── basic_oled_example.ino
+│   │   ├── display_config.h     # OLED init (SSD1306 or SH110X)
+│   │   ├── gps_config.h         # uBlox binary config commands
+│   │   └── images.h             # Bitmap data for UI
+│   ├── sector_timing_example/   # Demonstrates 3-sector timing
+│   │   └── sector_timing_example.ino
+│   └── real_track_data_debug/   # Replays real NMEA data (no GPS needed)
+│       ├── real_track_data_debug.ino
+│       ├── gps_race_data_2laps.h
+│       ├── gps_race_data_lap.h
+│       ├── gps_race_data_long_lap.h
+│       └── gps_race_data_praga_laps.h
+├── wokwi/                       # Wokwi simulator custom GPS chip
+│   ├── gps-fake.chip.c
+│   └── gps-fake.chip.json
+├── images/                      # Diagrams for HELPME.md
+├── library.properties           # Arduino library metadata
+├── README.md                    # User-facing docs and API reference
+├── HELPME.md                    # Technical deep-dive on crossing detection algorithm
+├── LICENSE                      # GPL v3 (conflicts with library.properties MIT claim)
+└── .github/FUNDING.yml
+```
+
+## Architecture & Key Concepts
+
+### Core Class: `DovesLapTimer`
+
+**Constructor**: `DovesLapTimer(double crossingThresholdMeters = 7, Stream *debugSerial = NULL)`
+
+### Main Loop Flow
+1. User calls `updateCurrentTime(millisecondsSinceMidnight)` with GPS time
+2. User calls `loop(lat, lng, altMeters, speedKnots)` on each GPS fix
+3. `loop()` updates odometer (haversine3D), speed, then checks all crossing lines
+4. `checkStartFinish()` and `checkSectorLine()` handle detection + interpolation
+
+### Crossing Detection Algorithm (the hard part)
+- Uses **hypotenuse-based threshold** (not simple distance-to-line)
+- Calculates hypotenuse from `crossingLineWidth` and `crossingThresholdMeters`
+- Checks driver distance to EACH endpoint of crossing line vs hypotenuse
+- When inside threshold: buffers GPS points in `crossingPointBuffer`
+- When exiting threshold: calls `interpolateCrossingPoint()` to find exact crossing
+
+### Interpolation Methods
+- **Linear** (default, `forceLinear = true`): distance+speed weighted interpolation
+- **Catmull-Rom spline**: uses 4 control points, falls back to linear if insufficient points
+- Known issue: Catmull-Rom has a bug (noted in basic_oled_example setup comment)
+
+### Sector Timing
+- 3 sectors: Start/Finish -> Sector2 -> Sector3 -> Start/Finish
+- Requires both sector 2 and sector 3 lines to be configured
+- Validates crossing order (rejects out-of-order crossings)
+- Tracks best sector times and lap numbers independently
+
+### Memory Management
+- Circular buffer `crossingPointBuffer` sized by available RAM:
+  - `>3000 bytes RAM`: 100 entries
+  - `<=3000 bytes RAM`: 25 entries
+- Buffer is shared between all line crossings (start/finish + sectors)
+- Mutual exclusion: only one line can be "crossing" at a time
+
+## Public API Quick Reference
+
+### Setup Methods
+| Method | Description |
+|--------|-------------|
+| `setStartFinishLine(aLat, aLng, bLat, bLng)` | Define start/finish line |
+| `setSector2Line(aLat, aLng, bLat, bLng)` | Define sector 2 split line |
+| `setSector3Line(aLat, aLng, bLat, bLng)` | Define sector 3 split line |
+| `updateCurrentTime(millisSinceMidnight)` | Set GPS time (call before loop) |
+| `forceLinearInterpolation()` | Use linear interpolation (default) |
+| `forceCatmullRomInterpolation()` | Use Catmull-Rom spline (has known issues) |
+| `reset()` | Reset all state to zero |
+
+### Timing Getters
+| Method | Returns |
+|--------|---------|
+| `getCurrentLapTime()` | Current lap elapsed ms |
+| `getLastLapTime()` | Last completed lap ms |
+| `getBestLapTime()` | Best lap ms |
+| `getCurrentLapSector1Time()` | Current lap S1 ms |
+| `getCurrentLapSector2Time()` | Current lap S2 ms |
+| `getCurrentLapSector3Time()` | Current lap S3 ms |
+| `getBestSector1Time()` | Best S1 ms (any lap) |
+| `getBestSector2Time()` | Best S2 ms (any lap) |
+| `getBestSector3Time()` | Best S3 ms (any lap) |
+| `getOptimalLapTime()` | Sum of best sectors |
+
+### State/Distance Getters
+| Method | Returns |
+|--------|---------|
+| `getRaceStarted()` | True after first line crossing |
+| `getCrossing()` | True while inside crossing zone |
+| `getLaps()` | Completed lap count |
+| `getBestLapNumber()` | Lap # of best time |
+| `getCurrentSector()` | 0=not started, 1/2/3 |
+| `areSectorLinesConfigured()` | True if both sector lines set |
+| `getCurrentLapDistance()` | Current lap meters |
+| `getLastLapDistance()` | Last lap meters |
+| `getBestLapDistance()` | Best lap meters |
+| `getTotalDistanceTraveled()` | Odometer meters |
+| `getPaceDifference()` | Pace delta vs best lap |
+
+### Public Utility Methods (also used by examples for display)
+| Method | Description |
+|--------|-------------|
+| `insideLineThreshold(...)` | Check if point is in crossing detection zone |
+| `pointLineSegmentDistance(...)` | Distance from point to line segment (meters) |
+| `haversine(lat1, lon1, lat2, lon2)` | Great-circle distance (meters) |
+| `haversine3D(...)` | 3D distance including altitude |
+| `isObtuseTriangle(...)` | Triangle type check |
+| `pointOnSideOfLine(...)` | Which side of line a point is on |
+
+## Known Issues & TODOs (from code comments)
+
+1. **Catmull-Rom interpolation bug**: basic_oled_example forces linear with comment "CURRENTLY REQUIRED: BUG IN CATMULROM INTERPOLATION METHOD"
+2. **Altitude messing up distance**: `loop()` line 27 has TODO: "I think alt is messing up, investigate more... maybe flag?"
+3. **Early abort bug**: checkStartFinish line 148-149 TODO about aborting early causing re-check immediately
+4. **`checkStartFinish` portability**: Line 106 TODO to make more portable for split timing
+5. **License mismatch**: GPL v3 in LICENSE file vs MIT in library.properties
+6. **Header comment outdated**: Says "single split time" but library supports 3 sectors now
+7. **No keywords.txt**: Missing for Arduino IDE syntax highlighting
+8. **No .gitignore**: Missing
+
+## Supported Hardware
+
+- **MCU**: Seeed XIAO nRF52840 (recommended), Arduino Mega+ (minimum)
+- **GPS**: Matek SAM-M10Q (25Hz), Matek SAM-M8Q (18Hz) - uBlox modules
+- **Display**: 128x64 I2C OLED (SSD1306 or SH110X)
+- **GPS Library**: Adafruit_GPS
+- **Display Library**: Adafruit GFX + Adafruit_SSD1306 or Adafruit_SH110x
+
+## Testing
+
+Use the `real_track_data_debug` example to replay real NMEA data without GPS hardware.
+Track data from Orlando Kart Center is included. Compare results against MyLaps timing.
+
+## Cross-Reference: Related Repos
+
+(Update this section as the other two repos are set up)
+- DovesLapTimer (this repo) - Core timing library
+- [Add other repos here as they are created]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ DovesLapTimer/
 
 ## Known Issues & TODOs (from code comments)
 
-1. **Catmull-Rom interpolation bug**: basic_oled_example forces linear with comment "CURRENTLY REQUIRED: BUG IN CATMULROM INTERPOLATION METHOD"
+1. ~~**Catmull-Rom interpolation bug**~~: Fixed - spline now only used for lat/lng (not time/odometer), and previous GPS fix inserted as pre-crossing control point
 2. **Altitude messing up distance**: `loop()` line 27 has TODO: "I think alt is messing up, investigate more... maybe flag?"
 3. **Early abort bug**: checkStartFinish line 148-149 TODO about aborting early causing re-check immediately
 4. **`checkStartFinish` portability**: Line 106 TODO to make more portable for split timing

--- a/examples/basic_oled_example/basic_oled_example.ino
+++ b/examples/basic_oled_example/basic_oled_example.ino
@@ -384,7 +384,7 @@ void displayStats() {
   // display.print(" LLD:");
   // display.print(lapTimer.getLastLapDistance());
   display.print("BLP:");
-  display.print(lapTimer.getBestLapTime() / lapTimer.getBestLapDistance());
+  display.print(lapTimer.getBestLapDistance() > 0 ? lapTimer.getBestLapTime() / lapTimer.getBestLapDistance() : 0);
   // display.print(" CLP:");
   // display.print(lapTimer.getCurrentLapTime() / lapTimer.getCurrentLapDistance());
   display.print(" MPH:");

--- a/examples/basic_oled_example/basic_oled_example.ino
+++ b/examples/basic_oled_example/basic_oled_example.ino
@@ -70,7 +70,7 @@ int ledState = LOW;
 unsigned long currentMillis;
 
 #include <DovesLapTimer.h>
-// initialize with internal debugger, and or crossingThreshold (default 10)
+// initialize with internal debugger, and or crossingThreshold (default 7)
 // Don't change this unless you know what you're doing
 double crossingThresholdMeters = 7.0;
 // DovesLapTimer lapTimer(crossingThresholdMeters, &DEBUG_SERIAL);
@@ -148,19 +148,18 @@ void gpsLoop() {
     }
 }
 
-#ifndef GPS_CONFIGURATION
-  /**
-   * @brief Sends a GPS configuration command stored in program memory to the GPS module via [GPS_SERIAL].
-   *
-   * This function reads a configuration command from PROGMEM (program memory) and sends it byte by byte to the GPS module using the [GPS_SERIAL] interface.
-   * The function also prints the configuration command in hexadecimal format for debugging purposes.
-   *
-   * @note This function contains blocking code and should be used during setup only.
-   *
-   * @param Progmem_ptr Pointer to the PROGMEM (program memory) containing the GPS configuration command.
-   * @param arraysize Size of the configuration command stored in PROGMEM.
-   */
-  void GPS_SendConfig(const uint8_t *Progmem_ptr, uint8_t arraysize) {
+/**
+ * @brief Sends a GPS configuration command stored in program memory to the GPS module via [GPS_SERIAL].
+ *
+ * This function reads a configuration command from PROGMEM (program memory) and sends it byte by byte to the GPS module using the [GPS_SERIAL] interface.
+ * The function also prints the configuration command in hexadecimal format for debugging purposes.
+ *
+ * @note This function contains blocking code and should be used during setup only.
+ *
+ * @param Progmem_ptr Pointer to the PROGMEM (program memory) containing the GPS configuration command.
+ * @param arraysize Size of the configuration command stored in PROGMEM.
+ */
+void GPS_SendConfig(const uint8_t *Progmem_ptr, uint8_t arraysize) {
     uint8_t byteread, index;
 
     debug(F("GPSSend  "));
@@ -186,218 +185,215 @@ void gpsLoop() {
       GPS_SERIAL.write(byteread);
     }
     delay(200);
+}
+
+void gpsSetup() {
+  // first try serial at 9600 baud
+  GPS_SERIAL.begin(9600);
+  // wait for the GPS to boot
+  delay(2250);
+  if (GPS_SERIAL) {
+    GPS_SendConfig(uart115200NmeaOnly, 28);
+    GPS_SERIAL.end();
   }
 
-  void gpsSetup() {
-    // first try serial at 9600 baud
-    GPS_SERIAL.begin(9600);
-    // wait for the GPS to boot
-    delay(2250);
-    if (GPS_SERIAL) {
-      GPS_SendConfig(uart115200NmeaOnly, 28);
-      GPS_SERIAL.end();
-    }
+  // reconnect at proper baud
+  gps = new Adafruit_GPS(&GPS_SERIAL);
+  GPS_SERIAL.begin(115200);
+  // wait for the GPS to boot
+  delay(2250);
+  // Send GPS Configurations
+  if (GPS_SERIAL) {
+    GPS_SendConfig(NMEAVersion23, 28);
+    GPS_SendConfig(FullPower, 16);
 
-    // reconnect at proper baud
-    gps = new Adafruit_GPS(&GPS_SERIAL);
-    GPS_SERIAL.begin(115200);
-    // wait for the GPS to boot
-    delay(2250);
-    // Send GPS Configurations
-    if (GPS_SERIAL) {
-      GPS_SendConfig(NMEAVersion23, 28);
-      GPS_SendConfig(FullPower, 16);
-
-      GPS_SendConfig(GPGLLOff, 16);
-      GPS_SendConfig(GPVTGOff, 16);
-      GPS_SendConfig(GPGSVOff, 16);
-      GPS_SendConfig(GPGSAOff, 16);
-      // GPS_SendConfig(GPGGAOn5, 16); // for 10hz
-      GPS_SendConfig(GPGGAOn10, 16); // for 18hz
-      GPS_SendConfig(NavTypeAutomobile, 44);
-      GPS_SendConfig(ENABLE_GPS_ONLY, 68);
-      // GPS_SendConfig(Navrate10hz, 14);
-      GPS_SendConfig(Navrate18hz, 14);
-    } else {
-      debugln("No GPS????");
-    }
+    GPS_SendConfig(GPGLLOff, 16);
+    GPS_SendConfig(GPVTGOff, 16);
+    GPS_SendConfig(GPGSVOff, 16);
+    GPS_SendConfig(GPGSAOff, 16);
+    // GPS_SendConfig(GPGGAOn5, 16); // for 10hz
+    GPS_SendConfig(GPGGAOn10, 16); // for 18hz
+    GPS_SendConfig(NavTypeAutomobile, 44);
+    GPS_SendConfig(ENABLE_GPS_ONLY, 68);
+    // GPS_SendConfig(Navrate10hz, 14);
+    GPS_SendConfig(Navrate18hz, 14);
+  } else {
+    debugln("No GPS????");
   }
-#endif
+}
 
-// setup / loop / pages
-#ifndef DISPLAY_FUNCTIONS
-  void displaySetup() {
-    debugln("SETTING UP DISPLAY");
-    delay(250); // wait for the OLED to power up
-    #ifdef USE_1306_DISPLAY
-      display.begin(SSD1306_SWITCHCAPVCC, I2C_DISPLAY_ADDRESS);
-    #else
-      display.begin(I2C_DISPLAY_ADDRESS, true);
-    #endif
-    display.setTextColor(DISPLAY_TEXT_WHITE);
-    display.setTextWrap(false);
-    display.setFont();
-    display.clearDisplay();
-    display.display();
+// Display functions
+void displaySetup() {
+  debugln("SETTING UP DISPLAY");
+  delay(250); // wait for the OLED to power up
+  #ifdef USE_1306_DISPLAY
+    display.begin(SSD1306_SWITCHCAPVCC, I2C_DISPLAY_ADDRESS);
+  #else
+    display.begin(I2C_DISPLAY_ADDRESS, true);
+  #endif
+  display.setTextColor(DISPLAY_TEXT_WHITE);
+  display.setTextWrap(false);
+  display.setFont();
+  display.clearDisplay();
+  display.display();
+  displayLastUpdate = millis();
+}
+
+void displayLoop() {
+  // Update Display
+  if (currentMillis - displayLastUpdate > (1000 / displayUpdateRateHz)) {
     displayLastUpdate = millis();
-  }
 
-  void displayLoop() {
-    // Update Display
-    if (currentMillis - displayLastUpdate > (1000 / displayUpdateRateHz)) {
-      displayLastUpdate = millis();
-
-      if (!lapTimer.getCrossing()) {
-        displayStats();
-      } else {
-        displayCrossing();
-      }
-    }
-  }
-
-  bool calculatingFlip = false;
-  void displayCrossing() {
-    display.clearDisplay();
-    display.setTextSize(1);
-    display.setCursor(0, 0);
-
-    // Draw bitmap on the screen
-    calculatingFlip = calculatingFlip == true ? false : true;
-    if (calculatingFlip) {
-      display.drawBitmap(0, 0, image_data_calculating1, 128, 64, 1);
+    if (!lapTimer.getCrossing()) {
+      displayStats();
     } else {
-      display.drawBitmap(0, 0, image_data_calculating2, 128, 64, 1);
+      displayCrossing();
     }
+  }
+}
 
-    display.display();
+bool calculatingFlip = false;
+void displayCrossing() {
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setCursor(0, 0);
+
+  // Draw bitmap on the screen
+  calculatingFlip = calculatingFlip == true ? false : true;
+  if (calculatingFlip) {
+    display.drawBitmap(0, 0, image_data_calculating1, 128, 64, 1);
+  } else {
+    display.drawBitmap(0, 0, image_data_calculating2, 128, 64, 1);
   }
 
-  void displayLoadPage() {
-    display.clearDisplay();
-    display.drawBitmap(0, 0, image_data_bird2, 128, 64, 1);
-    display.setCursor(0, 0);
-    display.setTextSize(1);
-    display.println("");
-    display.setTextSize(2);
-    display.setTextColor(DISPLAY_TEXT_BLACK);
-    display.println("Loading");
-    display.setTextColor(DISPLAY_TEXT_WHITE);
-    display.display();
-  }
+  display.display();
+}
 
-  bool activityFlasher = false;
-  unsigned long lastCurTime = -1;
-  unsigned long worstTimeDifference = 0;
-  void displayStats() {
-    display.clearDisplay();
-    display.setTextSize(1);
-    display.setCursor(0, 0);
+void displayLoadPage() {
+  display.clearDisplay();
+  display.drawBitmap(0, 0, image_data_bird2, 128, 64, 1);
+  display.setCursor(0, 0);
+  display.setTextSize(1);
+  display.println("");
+  display.setTextSize(2);
+  display.setTextColor(DISPLAY_TEXT_BLACK);
+  display.println("Loading");
+  display.setTextColor(DISPLAY_TEXT_WHITE);
+  display.display();
+}
 
-    display.print("Q:");
-    display.print(gps->fixquality);
+bool activityFlasher = false;
+unsigned long lastCurTime = -1;
+unsigned long worstTimeDifference = 0;
+void displayStats() {
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setCursor(0, 0);
 
-    display.print(" H:");
-    display.print(gps->HDOP, 2);
+  display.print("Q:");
+  display.print(gps->fixquality);
 
-    // this little derp here just lets me know the device is still working when the GPS hangs for a moment
-    display.print(" [");
-    activityFlasher = activityFlasher == true ? false : true;
-    display.print(activityFlasher == true ? "*" : " ");
-    display.print("|");
-    display.print(ledState == LOW ? "*" : " ");
-    display.print("] ");
+  display.print(" H:");
+  display.print(gps->HDOP, 2);
 
-    // debugging device "framerate"
-    display.print(frameRate, 1);
-    display.print("Hz");
+  // this little derp here just lets me know the device is still working when the GPS hangs for a moment
+  display.print(" [");
+  activityFlasher = activityFlasher == true ? false : true;
+  display.print(activityFlasher == true ? "*" : " ");
+  display.print("|");
+  display.print(ledState == LOW ? "*" : " ");
+  display.print("] ");
+
+  // debugging device "framerate"
+  display.print(frameRate, 1);
+  display.print("Hz");
 
 
-    display.println();
+  display.println();
 
-    display.print("St:");
-    display.print(gps->satellites);
-    display.print(" rs:");
-    display.print(lapTimer.getRaceStarted() == true ? "T" : "F");
-    display.print(" cr:");
-    display.print(lapTimer.getCrossing() == true ? "T" : "F");
-    display.print(" la:");
-    display.print(lapTimer.getLaps());
-    display.println();
+  display.print("St:");
+  display.print(gps->satellites);
+  display.print(" rs:");
+  display.print(lapTimer.getRaceStarted() == true ? "T" : "F");
+  display.print(" cr:");
+  display.print(lapTimer.getCrossing() == true ? "T" : "F");
+  display.print(" la:");
+  display.print(lapTimer.getLaps());
+  display.println();
 
-    display.print("CLT: ");
-    display.print(lapTimer.getCurrentLapTime() / 1000);
-    display.print(".");
-    display.print(lapTimer.getCurrentLapTime() % 1000);
-    // display.print(", ");
-    // display.print(lapTimer.lapTimer.getCurrentLapTime());
-    
-    // our wacky way of making sure the driver isnt off to the side and can "actually cross" the line
-    bool idnl = lapTimer.insideLineThreshold(
-      gps->latitudeDegrees, gps->longitudeDegrees,
-      crossingPointALat,
-      crossingPointALng,
-      crossingPointBLat,
-      crossingPointBLng
-    );
-    display.print(" LT:");
-    display.print(idnl == true ? "T" : "F");
-    display.print(":");
-    // our actual distance to the line reguardless
-    double dtl = lapTimer.pointLineSegmentDistance(
-      gps->latitudeDegrees, gps->longitudeDegrees,
-      crossingPointALat,
-      crossingPointALng,
-      crossingPointBLat,
-      crossingPointBLng
-    );
-    display.print(dtl);
-    display.println();
+  display.print("CLT: ");
+  display.print(lapTimer.getCurrentLapTime() / 1000);
+  display.print(".");
+  display.print(lapTimer.getCurrentLapTime() % 1000);
+  // display.print(", ");
+  // display.print(lapTimer.lapTimer.getCurrentLapTime());
 
-    display.print("B:");
-    display.print(lapTimer.getBestLapNumber());
-    display.print("-");
-    display.print(lapTimer.getBestLapTime() / 1000);
-    display.print(".");
-    display.print(lapTimer.getBestLapTime() % 1000);
-    display.print(" L: ");
-    display.print(lapTimer.getLastLapTime() / 1000);
-    display.print(".");
-    display.print(lapTimer.getLastLapTime() % 1000);
+  // our wacky way of making sure the driver isnt off to the side and can "actually cross" the line
+  bool idnl = lapTimer.insideLineThreshold(
+    gps->latitudeDegrees, gps->longitudeDegrees,
+    crossingPointALat,
+    crossingPointALng,
+    crossingPointBLat,
+    crossingPointBLng
+  );
+  display.print(" LT:");
+  display.print(idnl == true ? "T" : "F");
+  display.print(":");
+  // our actual distance to the line reguardless
+  double dtl = lapTimer.pointLineSegmentDistance(
+    gps->latitudeDegrees, gps->longitudeDegrees,
+    crossingPointALat,
+    crossingPointALng,
+    crossingPointBLat,
+    crossingPointBLng
+  );
+  display.print(dtl);
+  display.println();
 
-    // display.print("lapStart: ");
-    // display.println(lapTimer.getCurrentLapStartTime());
-    // display.print("CurTime: ");
-    // display.println(getGpsTimeInMilliseconds());
+  display.print("B:");
+  display.print(lapTimer.getBestLapNumber());
+  display.print("-");
+  display.print(lapTimer.getBestLapTime() / 1000);
+  display.print(".");
+  display.print(lapTimer.getBestLapTime() % 1000);
+  display.print(" L: ");
+  display.print(lapTimer.getLastLapTime() / 1000);
+  display.print(".");
+  display.print(lapTimer.getLastLapTime() % 1000);
 
-    display.println();
-    display.print("pace: ");
-    display.print(lapTimer.getPaceDifference(), 3);
-    display.print(" crD:");
-    display.print(lapTimer.getCurrentLapDistance());
+  // display.print("lapStart: ");
+  // display.println(lapTimer.getCurrentLapStartTime());
+  // display.print("CurTime: ");
+  // display.println(getGpsTimeInMilliseconds());
 
-    display.println();
-    display.print("AtM:");
-    display.print(gps->altitude);
-    display.print(" odo:");
-    display.print(lapTimer.getTotalDistanceTraveled());
+  display.println();
+  display.print("pace: ");
+  display.print(lapTimer.getPaceDifference(), 3);
+  display.print(" crD:");
+  display.print(lapTimer.getCurrentLapDistance());
 
-    display.println();   
-    // display.print("BLD:");
-    // display.print(lapTimer.getBestLapDistance());
-    // display.print(" LLD:");
-    // display.print(lapTimer.getLastLapDistance());
-    display.print("BLP:");
-    display.print(lapTimer.getBestLapTime() / lapTimer.getBestLapDistance());
-    // display.print(" CLP:");
-    // display.print(lapTimer.getCurrentLapTime() / lapTimer.getCurrentLapDistance());
-    display.print(" MPH:");
-    double speedMphFromKnots = gps->speed * 1.15078;
-    display.print(speedMphFromKnots, 2);
+  display.println();
+  display.print("AtM:");
+  display.print(gps->altitude);
+  display.print(" odo:");
+  display.print(lapTimer.getTotalDistanceTraveled());
 
-    display.println();
-    display.print("Time:");
-    display.println(getGpsTimeInMilliseconds());
+  display.println();
+  // display.print("BLD:");
+  // display.print(lapTimer.getBestLapDistance());
+  // display.print(" LLD:");
+  // display.print(lapTimer.getLastLapDistance());
+  display.print("BLP:");
+  display.print(lapTimer.getBestLapTime() / lapTimer.getBestLapDistance());
+  // display.print(" CLP:");
+  // display.print(lapTimer.getCurrentLapTime() / lapTimer.getCurrentLapDistance());
+  display.print(" MPH:");
+  double speedMphFromKnots = gps->speed * 1.15078;
+  display.print(speedMphFromKnots, 2);
 
-    display.display();
-  }
-#endif
+  display.println();
+  display.print("Time:");
+  display.println(getGpsTimeInMilliseconds());
+
+  display.display();
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,64 @@
+#######################################
+# Syntax Coloring Map For DovesLapTimer
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+DovesLapTimer	KEYWORD1
+crossingPointBufferEntry	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+loop	KEYWORD2
+setStartFinishLine	KEYWORD2
+setSector2Line	KEYWORD2
+setSector3Line	KEYWORD2
+updateCurrentTime	KEYWORD2
+forceLinearInterpolation	KEYWORD2
+forceCatmullRomInterpolation	KEYWORD2
+reset	KEYWORD2
+getRaceStarted	KEYWORD2
+getCrossing	KEYWORD2
+getCurrentLapStartTime	KEYWORD2
+getCurrentLapTime	KEYWORD2
+getLastLapTime	KEYWORD2
+getBestLapTime	KEYWORD2
+getCurrentLapOdometerStart	KEYWORD2
+getCurrentLapDistance	KEYWORD2
+getLastLapDistance	KEYWORD2
+getBestLapDistance	KEYWORD2
+getTotalDistanceTraveled	KEYWORD2
+getBestLapNumber	KEYWORD2
+getLaps	KEYWORD2
+getPaceDifference	KEYWORD2
+getBestSector1Time	KEYWORD2
+getBestSector2Time	KEYWORD2
+getBestSector3Time	KEYWORD2
+getCurrentLapSector1Time	KEYWORD2
+getCurrentLapSector2Time	KEYWORD2
+getCurrentLapSector3Time	KEYWORD2
+getOptimalLapTime	KEYWORD2
+getBestSector1LapNumber	KEYWORD2
+getBestSector2LapNumber	KEYWORD2
+getBestSector3LapNumber	KEYWORD2
+getCurrentSector	KEYWORD2
+areSectorLinesConfigured	KEYWORD2
+insideLineThreshold	KEYWORD2
+pointLineSegmentDistance	KEYWORD2
+haversine	KEYWORD2
+haversine3D	KEYWORD2
+isObtuseTriangle	KEYWORD2
+pointOnSideOfLine	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+CROSSING_LINE_SIDE_NONE	LITERAL1
+CROSSING_LINE_SIDE_A	LITERAL1
+CROSSING_LINE_SIDE_EXACT	LITERAL1
+CROSSING_LINE_SIDE_B	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DovesLapTimer
-version=3.1.0
+version=3.1.1
 author=Michael Champagne (crimsondove)
 maintainer=Michael Champagne
 sentence=A simple lap-timing library centered around GPS data
@@ -9,4 +9,3 @@ url=https://github.com/TheAngryRaven/DovesLapTimer
 architectures=*
 includes=DovesLapTimer.h
 depends=ArxTypeTraits
-

--- a/library.properties
+++ b/library.properties
@@ -9,3 +9,4 @@ url=https://github.com/TheAngryRaven/DovesLapTimer
 architectures=*
 includes=DovesLapTimer.h
 depends=ArxTypeTraits
+license=GPL-3.0

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -1,8 +1,8 @@
 /**
- * Originally intended to use for gokarting this library offers a simple way to get basic lap timing information from a GPS based system.
+ * GPS-based lap timing library for go-kart and racing applications.
  * This library does NOT interface with your GPS, simply feed it data and check the state.
- * Right now this only offers a single split time around the "start/finish" and would not work for many other purposes without modification.
- * 
+ * Supports start/finish line detection, 3-sector split timing, pace comparison, and distance tracking.
+ *
  * The development of this library has been overseen, and all documentation has been generated using chatGPT4.
  */
 
@@ -399,10 +399,10 @@ double DovesLapTimer::haversine(double lat1, double lon1, double lat2, double lo
   return distance;
 }
 
-double DovesLapTimer::haversine3D(double prevLat, double prevLng, double prevAlt, double currentLat, double curentLng, double currentAlt) {
+double DovesLapTimer::haversine3D(double prevLat, double prevLng, double prevAlt, double currentLat, double currentLng, double currentAlt) {
   double distWithAltitude = 0;
   if (prevLat != 0 && prevLng != 0) {
-    double dist = haversine(prevLat, prevLng, currentLat, curentLng);
+    double dist = haversine(prevLat, prevLng, currentLat, currentLng);
     double altDiff = currentAlt - prevAlt;
     distWithAltitude = sqrt(dist * dist + altDiff * altDiff);
   }

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -102,6 +102,14 @@ int DovesLapTimer::loop(double currentLat, double currentLng, float currentAltit
     }
   }
 
+  // Save current fix as previous for next iteration's Catmull-Rom pre-crossing point
+  prevFixLat = currentLat;
+  prevFixLng = currentLng;
+  prevFixTime = millisecondsSinceMidnight;
+  prevFixOdometer = totalDistanceTraveled;
+  prevFixSpeedKmh = currentSpeedkmh;
+  hasPrevFix = true;
+
   return nearAnyLine ? 0 : -1;
 }
 
@@ -256,9 +264,18 @@ bool DovesLapTimer::checkStartFinish(double currentLat, double currentLng) {
       debugln();
       debugln(F("we are possibly crossing"));
       crossing = true;
-      // crossingStartedLineSide = pointOnSideOfLine(currentLat, currentLng, startFinishPointALat, startFinishPointALng, startFinishPointBLat, startFinishPointBLng);
 
-      // Capture this first point - it's important context for Catmull-Rom interpolation
+      // Insert previous GPS fix as pre-crossing point (gives Catmull-Rom its p0 control point)
+      if (hasPrevFix) {
+        crossingPointBuffer[crossingPointBufferIndex].lat = prevFixLat;
+        crossingPointBuffer[crossingPointBufferIndex].lng = prevFixLng;
+        crossingPointBuffer[crossingPointBufferIndex].time = prevFixTime;
+        crossingPointBuffer[crossingPointBufferIndex].odometer = prevFixOdometer;
+        crossingPointBuffer[crossingPointBufferIndex].speedKmh = prevFixSpeedKmh;
+        crossingPointBufferIndex = (crossingPointBufferIndex + 1) % crossingPointBufferSize;
+      }
+
+      // Capture current point
       crossingPointBuffer[crossingPointBufferIndex].lat = currentLat;
       crossingPointBuffer[crossingPointBufferIndex].lng = currentLng;
       crossingPointBuffer[crossingPointBufferIndex].time = millisecondsSinceMidnight;
@@ -449,16 +466,15 @@ double DovesLapTimer::catmullRom(double p0, double p1, double p2, double p3, dou
 void DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossingLng, unsigned long& crossingTime, double& crossingOdometer, double pointALat, double pointALng, double pointBLat, double pointBLng) {
   int numPoints = crossingPointBufferFull ? crossingPointBufferSize : crossingPointBufferIndex;
 
-  // Variables to store the best pair of points
-  int bestIndexA = -1;
-  int bestIndexB = -1;
-  double bestSumDistances = INFINITY;
+  // Find the first pair of consecutive buffer points on opposite sides of the crossing line.
+  // In a normal pass there is exactly one such pair - the two GPS fixes that straddle the line.
+  int crossingIndexA = -1;
+  int crossingIndexB = -1;
+  double crossingSumDistances = INFINITY;
 
-  // Iterate through the crossingPointBuffer, comparing the sum of distances from the start/finish line of each pair of consecutive points
   for (int i = 0; i < numPoints - 1; i++) {
     double distA = pointLineSegmentDistance(crossingPointBuffer[i].lat, crossingPointBuffer[i].lng, pointALat, pointALng, pointBLat, pointBLng);
     double distB = pointLineSegmentDistance(crossingPointBuffer[i + 1].lat, crossingPointBuffer[i + 1].lng, pointALat, pointALng, pointBLat, pointBLng);
-    double sumDistances = distA + distB;
 
     int sideA = pointOnSideOfLine(crossingPointBuffer[i].lat, crossingPointBuffer[i].lng, pointALat, pointALng, pointBLat, pointBLng);
     int sideB = pointOnSideOfLine(crossingPointBuffer[i + 1].lat, crossingPointBuffer[i + 1].lng, pointALat, pointALng, pointBLat, pointBLng);
@@ -474,71 +490,64 @@ void DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
     debug(F(" sideB: "));
     debug(sideB);
     debug(F(" sum: "));
-    debugln(sumDistances, 2);
+    debugln(distA + distB, 2);
 
-    // Update the best pair of points if the current pair has a smaller sum of distances and the points are on opposite sides of the line
-    // todo: investigate if accuracy "on line" is good enough to avoid interpolation
-    if (sumDistances < bestSumDistances && sideA != sideB) {
-      debug(F("new best sum: "));
-      debugln(sumDistances, 2);
-      bestSumDistances = sumDistances;
-      bestIndexA = i;
-      bestIndexB = i + 1;
-      // this seems safe, as soon as we cross the line, no two points can be closer...
+    // First pair on opposite sides of the line = the crossing pair
+    if (sideA != sideB) {
+      crossingIndexA = i;
+      crossingIndexB = i + 1;
+      crossingSumDistances = distA + distB;
+      debug(F("crossing pair found, sum: "));
+      debugln(crossingSumDistances, 2);
       break;
     }
   }
-  debug(F("bestSumDistances: "));
-  debugln(bestSumDistances);
+  debug(F("crossingSumDistances: "));
+  debugln(crossingSumDistances);
 
-  // Make sure we found a valid pair of points
-  if (bestSumDistances < crossingThresholdMeters && bestIndexA != -1 && bestIndexB != -1) {
+  // Validate: the crossing pair must exist and be close enough to the line
+  if (crossingSumDistances < crossingThresholdMeters && crossingIndexA != -1 && crossingIndexB != -1) {
     debugln(F("~~~ VALID CROSSING ~~~"));
 
+    // Compute the interpolation factor (t) from distances and speeds at the crossing pair
+    double distA = pointLineSegmentDistance(crossingPointBuffer[crossingIndexA].lat, crossingPointBuffer[crossingIndexA].lng, pointALat, pointALng, pointBLat, pointBLng);
+    double distB = pointLineSegmentDistance(crossingPointBuffer[crossingIndexB].lat, crossingPointBuffer[crossingIndexB].lng, pointALat, pointALng, pointBLat, pointBLng);
+    double t = interpolateWeight(distA, distB, crossingPointBuffer[crossingIndexA].speedKmh, crossingPointBuffer[crossingIndexB].speedKmh);
+
+    // Time and odometer are always interpolated linearly (monotonic values that
+    // should not overshoot), regardless of the interpolation mode for position.
+    double deltaOdometer = crossingPointBuffer[crossingIndexB].odometer - crossingPointBuffer[crossingIndexA].odometer;
+    double deltaTime = crossingPointBuffer[crossingIndexB].time - crossingPointBuffer[crossingIndexA].time;
+    crossingOdometer = crossingPointBuffer[crossingIndexA].odometer + t * deltaOdometer;
+    crossingTime = crossingPointBuffer[crossingIndexA].time + t * deltaTime;
+
     if (forceLinear) {
-      // Linear interpolation
-      double distA = pointLineSegmentDistance(crossingPointBuffer[bestIndexA].lat, crossingPointBuffer[bestIndexA].lng, pointALat, pointALng, pointBLat, pointBLng);
-      double distB = pointLineSegmentDistance(crossingPointBuffer[bestIndexB].lat, crossingPointBuffer[bestIndexB].lng, pointALat, pointALng, pointBLat, pointBLng);
-      double t = interpolateWeight(distA, distB, crossingPointBuffer[bestIndexA].speedKmh, crossingPointBuffer[bestIndexB].speedKmh);
+      // Linear interpolation for position
+      double deltaLat = crossingPointBuffer[crossingIndexB].lat - crossingPointBuffer[crossingIndexA].lat;
+      double deltaLon = crossingPointBuffer[crossingIndexB].lng - crossingPointBuffer[crossingIndexA].lng;
 
-      double deltaLat = crossingPointBuffer[bestIndexB].lat - crossingPointBuffer[bestIndexA].lat;
-      double deltaLon = crossingPointBuffer[bestIndexB].lng - crossingPointBuffer[bestIndexA].lng;
-      double deltaOdometer = crossingPointBuffer[bestIndexB].odometer - crossingPointBuffer[bestIndexA].odometer;
-      double deltaTime = crossingPointBuffer[bestIndexB].time - crossingPointBuffer[bestIndexA].time;
-
-      crossingLat = crossingPointBuffer[bestIndexA].lat + t * deltaLat;
-      crossingLng = crossingPointBuffer[bestIndexA].lng + t * deltaLon;
-      crossingOdometer = crossingPointBuffer[bestIndexA].odometer + t * deltaOdometer;
-      crossingTime = crossingPointBuffer[bestIndexA].time + t * deltaTime;
+      crossingLat = crossingPointBuffer[crossingIndexA].lat + t * deltaLat;
+      crossingLng = crossingPointBuffer[crossingIndexA].lng + t * deltaLon;
     } else {
-      // Catmull-Rom spline interpolation requires 4 control points:
-      // index0 (before A), index1 (A), index2 (B), index3 (after B)
-      // Check bounds: we need bestIndexA >= 1 and bestIndexB <= numPoints - 2
-      bool canUseCatmullRom = (bestIndexA >= 1) && (bestIndexB <= numPoints - 2);
+      // Catmull-Rom spline interpolation for position only.
+      // Requires 4 control points: p0 (before A), p1 (A), p2 (B), p3 (after B)
+      bool canUseCatmullRom = (crossingIndexA >= 1) && (crossingIndexB <= numPoints - 2);
 
       if (!canUseCatmullRom) {
-        // Not enough points for Catmull-Rom, fall back to linear interpolation
+        // Not enough points for Catmull-Rom, fall back to linear
         debugln(F("Catmull-Rom: insufficient control points, using linear fallback"));
 
-        double distA = pointLineSegmentDistance(crossingPointBuffer[bestIndexA].lat, crossingPointBuffer[bestIndexA].lng, pointALat, pointALng, pointBLat, pointBLng);
-        double distB = pointLineSegmentDistance(crossingPointBuffer[bestIndexB].lat, crossingPointBuffer[bestIndexB].lng, pointALat, pointALng, pointBLat, pointBLng);
-        double t = interpolateWeight(distA, distB, crossingPointBuffer[bestIndexA].speedKmh, crossingPointBuffer[bestIndexB].speedKmh);
+        double deltaLat = crossingPointBuffer[crossingIndexB].lat - crossingPointBuffer[crossingIndexA].lat;
+        double deltaLon = crossingPointBuffer[crossingIndexB].lng - crossingPointBuffer[crossingIndexA].lng;
 
-        double deltaLat = crossingPointBuffer[bestIndexB].lat - crossingPointBuffer[bestIndexA].lat;
-        double deltaLon = crossingPointBuffer[bestIndexB].lng - crossingPointBuffer[bestIndexA].lng;
-        double deltaOdometer = crossingPointBuffer[bestIndexB].odometer - crossingPointBuffer[bestIndexA].odometer;
-        double deltaTime = crossingPointBuffer[bestIndexB].time - crossingPointBuffer[bestIndexA].time;
-
-        crossingLat = crossingPointBuffer[bestIndexA].lat + t * deltaLat;
-        crossingLng = crossingPointBuffer[bestIndexA].lng + t * deltaLon;
-        crossingOdometer = crossingPointBuffer[bestIndexA].odometer + t * deltaOdometer;
-        crossingTime = crossingPointBuffer[bestIndexA].time + t * deltaTime;
+        crossingLat = crossingPointBuffer[crossingIndexA].lat + t * deltaLat;
+        crossingLng = crossingPointBuffer[crossingIndexA].lng + t * deltaLon;
       } else {
         // We have 4 valid control points for Catmull-Rom
-        int index0 = bestIndexA - 1;
-        int index1 = bestIndexA;
-        int index2 = bestIndexB;
-        int index3 = bestIndexB + 1;
+        int index0 = crossingIndexA - 1;
+        int index1 = crossingIndexA;
+        int index2 = crossingIndexB;
+        int index3 = crossingIndexB + 1;
 
         debugln(F("Catmull-Rom: using spline interpolation"));
         debug(F("  indices: "));
@@ -550,22 +559,14 @@ void DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
         debug(F(", "));
         debugln(index3);
 
-        // Compute the interpolation factor based on distance and speed
-        double distA = pointLineSegmentDistance(crossingPointBuffer[index1].lat, crossingPointBuffer[index1].lng, pointALat, pointALng, pointBLat, pointBLng);
-        double distB = pointLineSegmentDistance(crossingPointBuffer[index2].lat, crossingPointBuffer[index2].lng, pointALat, pointALng, pointBLat, pointBLng);
-        double t = interpolateWeight(distA, distB, crossingPointBuffer[index1].speedKmh, crossingPointBuffer[index2].speedKmh);
-
-        // Perform Catmull-Rom spline interpolation for latitude, longitude, time, and odometer
+        // Catmull-Rom for lat/lng only - spline smoothing helps with curved paths
         crossingLat = catmullRom(crossingPointBuffer[index0].lat, crossingPointBuffer[index1].lat, crossingPointBuffer[index2].lat, crossingPointBuffer[index3].lat, t);
         crossingLng = catmullRom(crossingPointBuffer[index0].lng, crossingPointBuffer[index1].lng, crossingPointBuffer[index2].lng, crossingPointBuffer[index3].lng, t);
-        crossingTime = catmullRom(crossingPointBuffer[index0].time, crossingPointBuffer[index1].time, crossingPointBuffer[index2].time, crossingPointBuffer[index3].time, t);
-        crossingOdometer = catmullRom(crossingPointBuffer[index0].odometer, crossingPointBuffer[index1].odometer, crossingPointBuffer[index2].odometer, crossingPointBuffer[index3].odometer, t);
       }
     }
   } else {
     debugln(F("~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~"));
   }
-  return;
 }
 
 /////////// sector timing helper methods
@@ -736,7 +737,17 @@ bool DovesLapTimer::checkSectorLine(double currentLat, double currentLng, double
       debugln(F(" crossing zone"));
       crossingFlag = true;
 
-      // Capture this first point - it's important context for Catmull-Rom interpolation
+      // Insert previous GPS fix as pre-crossing point (gives Catmull-Rom its p0 control point)
+      if (hasPrevFix) {
+        crossingPointBuffer[crossingPointBufferIndex].lat = prevFixLat;
+        crossingPointBuffer[crossingPointBufferIndex].lng = prevFixLng;
+        crossingPointBuffer[crossingPointBufferIndex].time = prevFixTime;
+        crossingPointBuffer[crossingPointBufferIndex].odometer = prevFixOdometer;
+        crossingPointBuffer[crossingPointBufferIndex].speedKmh = prevFixSpeedKmh;
+        crossingPointBufferIndex = (crossingPointBufferIndex + 1) % crossingPointBufferSize;
+      }
+
+      // Capture current point
       crossingPointBuffer[crossingPointBufferIndex].lat = currentLat;
       crossingPointBuffer[crossingPointBufferIndex].lng = currentLng;
       crossingPointBuffer[crossingPointBufferIndex].time = millisecondsSinceMidnight;
@@ -789,6 +800,12 @@ void DovesLapTimer::reset() {
   positionPrevLng = 0;
   positionPrevAlt = 0;
   firstPositionReceived = false;
+  prevFixLat = 0;
+  prevFixLng = 0;
+  prevFixTime = 0;
+  prevFixOdometer = 0;
+  prevFixSpeedKmh = 0;
+  hasPrevFix = false;
 
   // Reset the crossingPointBuffer index and full status
   crossing = false;

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -51,14 +51,16 @@ int DovesLapTimer::loop(double currentLat, double currentLng, float currentAltit
   currentSpeedkmh = currentSpeedKnots * 1.852;
 
   // run calculations for each crossing-line
-  // Priority order: check whichever line we're currently crossing first,
-  // then check others. Only one line can be "crossing" at a time due to shared buffer.
+  // Only one line can be "crossing" at a time due to shared buffer.
+  // Mutual exclusion: skip start/finish if a sector crossing is active, and vice versa.
 
   bool nearAnyLine = false;
 
-  // Always check start/finish line
-  if (this->checkStartFinish(currentLat, currentLng)) {
-    nearAnyLine = true;
+  // Check start/finish line - skip if a sector crossing is already in progress
+  if (crossing || (!crossingSector2 && !crossingSector3)) {
+    if (this->checkStartFinish(currentLat, currentLng)) {
+      nearAnyLine = true;
+    }
   }
 
   // Check sector lines if configured and not currently crossing start/finish

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -378,8 +378,6 @@ double DovesLapTimer::pointLineSegmentDistance(double pointX, double pointY, dou
 }
 
 double DovesLapTimer::haversine(double lat1, double lon1, double lat2, double lon2) {
-  double radiusEarth = 6371000; // Earth's radius in meters
-
   // Convert latitude and longitude from degrees to radians
   double lat1Rad = radians(lat1);
   double lon1Rad = radians(lon1);
@@ -400,13 +398,9 @@ double DovesLapTimer::haversine(double lat1, double lon1, double lat2, double lo
 }
 
 double DovesLapTimer::haversine3D(double prevLat, double prevLng, double prevAlt, double currentLat, double currentLng, double currentAlt) {
-  double distWithAltitude = 0;
-  if (prevLat != 0 && prevLng != 0) {
-    double dist = haversine(prevLat, prevLng, currentLat, currentLng);
-    double altDiff = currentAlt - prevAlt;
-    distWithAltitude = sqrt(dist * dist + altDiff * altDiff);
-  }
-  return distWithAltitude;
+  double dist = haversine(prevLat, prevLng, currentLat, currentLng);
+  double altDiff = currentAlt - prevAlt;
+  return sqrt(dist * dist + altDiff * altDiff);
 }
 
 /////////// private functions
@@ -456,7 +450,7 @@ void DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
   // Variables to store the best pair of points
   int bestIndexA = -1;
   int bestIndexB = -1;
-  double bestSumDistances = 100000.0;
+  double bestSumDistances = INFINITY;
 
   // Iterate through the crossingPointBuffer, comparing the sum of distances from the start/finish line of each pair of consecutive points
   for (int i = 0; i < numPoints - 1; i++) {
@@ -783,6 +777,9 @@ void DovesLapTimer::reset() {
   bestSector1LapNumber = 0;
   bestSector2LapNumber = 0;
   bestSector3LapNumber = 0;
+
+  // reset time tracking
+  millisecondsSinceMidnight = 0;
 
   // reset odometer and position tracking
   totalDistanceTraveled = 0;

--- a/src/DovesLapTimer.h
+++ b/src/DovesLapTimer.h
@@ -452,7 +452,7 @@ private:
 
   Stream *_serial;
   
-  unsigned long millisecondsSinceMidnight = -1;
+  unsigned long millisecondsSinceMidnight = 0;
   // Timing variables
   double crossingThresholdMeters;
   bool raceStarted = false;

--- a/src/DovesLapTimer.h
+++ b/src/DovesLapTimer.h
@@ -496,6 +496,14 @@ private:
   double positionPrevLng = 0.00;
   bool firstPositionReceived = false;  // Explicit flag for first GPS fix detection
 
+  // Previous GPS fix snapshot (used as Catmull-Rom pre-crossing control point)
+  double prevFixLat = 0;
+  double prevFixLng = 0;
+  unsigned long prevFixTime = 0;
+  float prevFixOdometer = 0;
+  float prevFixSpeedKmh = 0;
+  bool hasPrevFix = false;
+
   double startFinishPointALat;
   double startFinishPointALng;
   double startFinishPointBLat;

--- a/src/DovesLapTimer.h
+++ b/src/DovesLapTimer.h
@@ -1,8 +1,8 @@
 /**
- * Originally intended to use for gokarting this library offers a simple way to get basic lap timing information from a GPS based system.
+ * GPS-based lap timing library for go-kart and racing applications.
  * This library does NOT interface with your GPS, simply feed it data and check the state.
- * Right now this only offers a single split time around the "start/finish" and would not work for many other purposes without modification.
- * 
+ * Supports start/finish line detection, 3-sector split timing, pace comparison, and distance tracking.
+ *
  * The development of this library has been overseen, and all documentation has been generated using chatGPT4.
  */
 
@@ -138,7 +138,7 @@ public:
    * @param currentAlt Altitude of the second GPS point in meters.
    * @return The 3D distance between the two GPS points in meters.
    */
-  double haversine3D(double prevLat, double prevLng, double prevAlt, double currentLat, double curentLng, double currentAlt);
+  double haversine3D(double prevLat, double prevLng, double prevAlt, double currentLat, double currentLng, double currentAlt);
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Summary

Full code review of the DovesLapTimer library, addressing 15 issues across 4 severity levels.

### Critical fixes
- **License mismatch resolved**: Added `license=GPL-3.0` to `library.properties` to match the GPL v3 LICENSE file
- **Shared crossing buffer mutual exclusion**: `checkStartFinish` now skipped while a sector crossing is active, preventing buffer corruption when lines are physically close on a track
- **`millisecondsSinceMidnight` init**: Changed from `-1` (ULONG_MAX) to `0` to prevent garbage timestamps
- **Catmull-Rom interpolation bugs**: Root cause of the known bug found and fixed:
  - Spline overshoot on time/odometer produced garbage `unsigned long` values; now only lat/lng use Catmull-Rom, time/odometer always use linear
  - Previous GPS fix now stored and inserted as pre-crossing buffer entry, giving Catmull-Rom its p0 control point on fast passes

### Moderate fixes
- `haversine3D` guard removed (caller already gates with `firstPositionReceived`)
- Shadowed `radiusEarth` local variable removed from `haversine()`
- Division by zero guarded in `basic_oled_example` display code
- `reset()` now resets `millisecondsSinceMidnight`
- Magic number `100000.0` replaced with `INFINITY`

### Minor fixes
- Typo `curentLng` -> `currentLng` in header and implementation
- Outdated header comments updated (said "single split" but library has 3-sector timing)
- Example comment corrected: default threshold is 7, not 10
- Removed fake `#ifndef` guards in `basic_oled_example` that served no purpose
- Added `keywords.txt` for Arduino IDE syntax highlighting
- Added `.gitignore`

### Cleanup
- `interpolateCrossingPoint` search loop: renamed misleading "best" variables, removed dead comparison, deduplicated computation across branches
- Added `CLAUDE.md` project documentation for future development sessions

## Test plan
- [ ] Flash `real_track_data_debug` example and verify lap times match previous results (linear interpolation)
- [ ] Test with `forceCatmullRomInterpolation()` enabled and verify no garbage lap times
- [ ] Verify sector timing still works correctly with the mutual exclusion changes
- [ ] Confirm `keywords.txt` highlights correctly in Arduino IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)