### PR TITLE
fix three course detection bugs ported from the webapp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,14 @@ CourseManager (orchestrator)
 
 ### Direction Detection (v4.0)
 - `DirectionDetector` struct inline in `DovesLapTimer.h`
-- After start/finish crossed (`raceSeen = true`), first sector line determines direction
-- S2 first = forward (`DIR_FORWARD`), S3 first = reverse (`DIR_REVERSE`)
+- After start/finish crossed (`raceSeen = true`), captures **physical** S2 and S3
+  crossing timestamps in a per-lap window (`lapS2CrossingTime`, `lapS3CrossingTime`)
+- At the next start/finish, if BOTH timestamps were captured this lap, direction
+  resolves: `s2 < s3` → `DIR_FORWARD`, otherwise `DIR_REVERSE`
+- Single-sector laps (driver missed a poorly-placed line or GPS rate too low to
+  catch the zone) are discarded — the window resets and we re-try next lap
+- Latest in-lap crossing wins: a phantom GPS glitch early in the lap gets
+  overwritten by the real crossing that follows
 - Once resolved, direction is locked. `handleLineCrossing()` remaps S2↔S3 when reverse
 - Getters: `getDirection()`, `isDirectionResolved()`
 
@@ -108,6 +114,11 @@ CourseManager (orchestrator)
 - Drops waypoint when speed >= 20 mph, waits for return within 10m after 200m+ traveled
 - Compares driven distance (feet) to each course's `lengthFt` within 25% tolerance
 - Builds ranked candidates, CourseManager validates via `raceStarted` sanity check
+- `rejectAllCandidates(currentOdometer)` advances `_waypointOdometer` to "now"
+  so a rejection requires another full lap before re-ranking — otherwise the
+  driver is still inside the proximity zone and the next GPS fix would
+  re-trigger ranking, burning through `COURSE_DETECT_MAX_REJECTIONS` in a few
+  frames and jumping straight to Lap Anything
 
 ### WaypointLapTimer ("Lap Anything") (v4.0)
 - Fallback when no course is detected (after 3 rejections)
@@ -267,6 +278,9 @@ struct TrackConfig {
 8. ~~**No .gitignore**~~: Added
 9. **nRF52840 RAM budget unaffected by AVR macros**: `DovesLapTimer.h` buffer-size `#if` now uses `defined(RAMEND) && defined(RAMSTART)` as the AVR detection gate; non-AVR targets get the 100-entry buffer unconditionally.
 10. **Haversine hot-path micro-opt (2026-04-17)**: `pow(x, 2)` replaced with `x*x` in `GeoMath.h::geoHaversine` and `DovesLapTimer.cpp::pointLineSegmentDistance` for consistency with the existing `sq()` usage elsewhere — same output, fewer library calls.
+11. ~~**Direction detector mis-classified forward as reverse**~~: Fixed (2026-05-20). `DirectionDetector::onLineCrossing` used to lock direction from whichever single sector line (S2 or S3) was hit first after `raceSeen`. A poorly-placed sector line that the racing line missed (or low GPS sample rate that skipped the zone) caused S3 to be hit "first", flipping direction to reverse forever. Now requires BOTH physical S2 and S3 to be crossed within a lap window and decides from their temporal order at the next start/finish. Same root cause as the ported webapp bug `courseDetection.ts:67-90`.
+12. ~~**Direction lockout on glitched first crossing**~~: Fixed (2026-05-20). Same change as #11. The old "first crossing wins" rule meant a single GPS teleport that triggered a phantom S3 crossing locked direction to reverse permanently. The new logic requires both sector lines and lets the *latest* in-lap crossing overwrite earlier phantoms, dramatically shrinking the surface area for a single glitch to mis-lock. Same root cause as the ported webapp bug `lapCalculation.ts:107`. Note: a glitch that fabricates BOTH sector crossings on the same lap could still mis-lock — a multi-lap voting threshold would harden this further but was deferred.
+13. ~~**CourseManager burned through MAX_REJECTIONS in a few GPS frames**~~: Fixed (2026-05-20). When `_handleCandidatesReady` rejected all candidates, `rejectAllCandidates()` only reset state to `WAYPOINT_SET`; the driver was still inside waypoint proximity with `distanceSinceWaypoint` still well above the 200m gate, so the very next GPS fix re-triggered ranking → same candidates → reject → repeat. At 25 Hz this burned all 3 rejections in ~120 ms, falling straight to Lap Anything without the driver completing another real lap. Fix: `rejectAllCandidates(currentOdometer)` now advances `_waypointOdometer` to "now", so the next ranking pass requires another full lap (200m+ traveled and returned to proximity).
 
 ## Supported Hardware
 

--- a/src/CourseDetector.cpp
+++ b/src/CourseDetector.cpp
@@ -109,9 +109,14 @@ void CourseDetector::acceptCandidate(int index) {
   _state = DETECT_STATE_DETECTED;
 }
 
-void CourseDetector::rejectAllCandidates() {
+void CourseDetector::rejectAllCandidates(float currentOdometer) {
   _rankedMatchCount = 0;
   _state = DETECT_STATE_WAYPOINT_SET;
+  // Advance the lap-window origin to "now". Without this, the driver is
+  // still inside the waypoint proximity and still meets the min-distance
+  // gate, so the very next GPS fix would re-rank the same candidates and
+  // we'd burn through MAX_REJECTIONS in a handful of frames.
+  _waypointOdometer = currentOdometer;
 }
 
 void CourseDetector::setSpeedThresholdMph(float mph) {

--- a/src/CourseDetector.h
+++ b/src/CourseDetector.h
@@ -33,7 +33,10 @@ public:
   void init(CourseInfo* courses, int count);
   void update(double lat, double lng, float speedKmh, float totalOdometer);
   void acceptCandidate(int index);
-  void rejectAllCandidates();
+  // currentOdometer advances the waypoint's lap-window start so the next
+  // ranking pass requires another full lap, rather than immediately
+  // re-ranking while still in proximity.
+  void rejectAllCandidates(float currentOdometer);
   void reset();
   void setSpeedThresholdMph(float mph);
   void setDetectionProximityMeters(float meters);

--- a/src/CourseManager.cpp
+++ b/src/CourseManager.cpp
@@ -122,14 +122,14 @@ int CourseManager::loop(double lat, double lng, float altMeters, float speedKnot
 
     // Handle candidates_ready state
     if (_detector.getState() == DETECT_STATE_CANDIDATES_READY) {
-      _handleCandidatesReady();
+      _handleCandidatesReady(odometer);
     }
   }
 
   return -1;
 }
 
-void CourseManager::_handleCandidatesReady() {
+void CourseManager::_handleCandidatesReady(float currentOdometer) {
   int matchCount = _detector.getRankedMatchCount();
   const DetectionCandidate* matches = _detector.getRankedMatches();
 
@@ -146,8 +146,10 @@ void CourseManager::_handleCandidatesReady() {
     }
   }
 
-  // No candidate had raceStarted — reject all
-  _detector.rejectAllCandidates();
+  // No candidate had raceStarted — reject all. Pass current odometer so the
+  // detector advances its lap-window origin; otherwise the next GPS fix
+  // would re-rank the same candidates and we'd burn the rejection budget.
+  _detector.rejectAllCandidates(currentOdometer);
   _detectionRejectionCount++;
   debug(F("Detection rejected ("));
   debug(_detectionRejectionCount);

--- a/src/CourseManager.h
+++ b/src/CourseManager.h
@@ -85,7 +85,7 @@ private:
   }
 
   void _initCourses(TrackConfig& config);
-  void _handleCandidatesReady();
+  void _handleCandidatesReady(float currentOdometer);
   void _activateLapAnything();
 
   Stream *_serial;

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -515,8 +515,18 @@ void DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
 
 /////////// direction detection
 
-void DirectionDetector::onLineCrossing(int sectorNumber) {
+void DirectionDetector::onLineCrossing(int sectorNumber, unsigned long crossingTime) {
   if (sectorNumber == 0) {
+    // Start/finish crossed. If we've collected both S2 and S3 timestamps in
+    // the current lap window, resolve direction from their temporal order.
+    // Single-sector laps (driver missed a poorly-placed line, or GPS rate
+    // too low to catch the zone) are discarded and re-tried next lap.
+    if (raceSeen && direction == DIR_UNKNOWN
+        && lapS2CrossingTime != 0 && lapS3CrossingTime != 0) {
+      direction = (lapS2CrossingTime < lapS3CrossingTime) ? DIR_FORWARD : DIR_REVERSE;
+    }
+    lapS2CrossingTime = 0;
+    lapS3CrossingTime = 0;
     raceSeen = true;
     return;
   }
@@ -529,10 +539,12 @@ void DirectionDetector::onLineCrossing(int sectorNumber) {
     return;
   }
 
+  // Latest crossing wins inside a lap so a phantom glitch early in the lap
+  // gets overwritten by the real crossing later on.
   if (sectorNumber == 2) {
-    direction = DIR_FORWARD;
+    lapS2CrossingTime = crossingTime;
   } else if (sectorNumber == 3) {
-    direction = DIR_REVERSE;
+    lapS3CrossingTime = crossingTime;
   }
 }
 
@@ -544,8 +556,9 @@ void DovesLapTimer::handleLineCrossing(unsigned long crossingTime, int sectorNum
     return;
   }
 
-  // Feed direction detector with raw (physical) sector number
-  _directionDetector.onLineCrossing(sectorNumber);
+  // Feed direction detector with raw (physical) sector number and crossing
+  // time so it can compare S2 vs S3 timestamps to infer direction.
+  _directionDetector.onLineCrossing(sectorNumber, crossingTime);
 
   // Remap sector number for reverse direction (swap 2<->3)
   int effectiveSector = sectorNumber;

--- a/src/DovesLapTimer.h
+++ b/src/DovesLapTimer.h
@@ -56,10 +56,22 @@ struct crossingPointBufferEntry {
 struct DirectionDetector {
   int direction;    // DIR_UNKNOWN, DIR_FORWARD, DIR_REVERSE
   bool raceSeen;
+  // Per-lap window: timestamps of physical S2/S3 crossings since the last
+  // start/finish. Direction is decided only when BOTH are present, by their
+  // temporal order — independent of the lap calculation's sector output.
+  unsigned long lapS2CrossingTime;
+  unsigned long lapS3CrossingTime;
 
-  DirectionDetector() : direction(DIR_UNKNOWN), raceSeen(false) {}
-  void reset() { direction = DIR_UNKNOWN; raceSeen = false; }
-  void onLineCrossing(int sectorNumber);
+  DirectionDetector()
+    : direction(DIR_UNKNOWN), raceSeen(false),
+      lapS2CrossingTime(0), lapS3CrossingTime(0) {}
+  void reset() {
+    direction = DIR_UNKNOWN;
+    raceSeen = false;
+    lapS2CrossingTime = 0;
+    lapS3CrossingTime = 0;
+  }
+  void onLineCrossing(int sectorNumber, unsigned long crossingTime);
   bool isReverse() const { return direction == DIR_REVERSE; }
   bool isResolved() const { return direction != DIR_UNKNOWN; }
 };


### PR DESCRIPTION
DirectionDetector previously locked direction from the first sector line
hit after raceSeen. A poorly-placed S2 line that the racing line missed
(or low GPS sample rate that skipped the zone) caused S3 to be hit
"first", permanently mis-classifying direction as reverse. A single
teleport glitch had the same effect. Now requires both physical S2 and
S3 to be captured in a lap window and resolves direction from their
temporal order at the next start/finish; latest in-lap crossing wins so
phantoms get overwritten by real crossings.

CourseManager rejection burned through MAX_REJECTIONS in ~120ms at 25Hz:
rejectAllCandidates only reset state, leaving the driver still inside
proximity and well past the 200m gate, so the next GPS fix re-ranked the
same candidates. rejectAllCandidates(currentOdometer) now advances
_waypointOdometer so re-ranking requires another full lap.