### PR TITLE
ci: add arduino-lint + compile-examples GitHub Actions (layer 1)

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,33 @@
+name: arduino-lint
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: arduino-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v2
+        with:
+          project-type: library
+          compliance: specification
+          library-manager: update
+          report-file: arduino-lint-report.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: arduino-lint-report
+          path: arduino-lint-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,85 @@
+name: compile-examples
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: ${{ matrix.board.alias }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          # Arduino Mega (AVR, has Serial1) — all examples
+          - alias: arduino-mega
+            fqbn: arduino:avr:mega
+            platforms: |
+              - name: arduino:avr
+            sketch-paths: |
+              - examples/basic_oled_example
+              - examples/sector_timing_example
+              - examples/real_track_data_debug
+
+          # Arduino Uno (AVR, no Serial1) — only the portable sketch
+          # smoke test that the core library still builds on a small AVR
+          - alias: arduino-uno
+            fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+            sketch-paths: |
+              - examples/sector_timing_example
+
+          # ESP32 — all examples
+          - alias: esp32
+            fqbn: esp32:esp32:esp32
+            platforms: |
+              - name: esp32:esp32
+                source-url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+            sketch-paths: |
+              - examples/basic_oled_example
+              - examples/sector_timing_example
+              - examples/real_track_data_debug
+
+          # Seeed XIAO nRF52840 (recommended hardware) — all examples
+          - alias: xiao-nrf52840
+            fqbn: Seeeduino:mbed:xiaonRF52840
+            platforms: |
+              - name: Seeeduino:mbed
+                source-url: https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
+            sketch-paths: |
+              - examples/basic_oled_example
+              - examples/sector_timing_example
+              - examples/real_track_data_debug
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile sketches
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            - source-path: ./
+            - name: ArxTypeTraits
+            - name: Adafruit GPS Library
+            - name: Adafruit GFX Library
+            - name: Adafruit SSD1306
+            - name: Adafruit SH110X
+          sketch-paths: ${{ matrix.board.sketch-paths }}
+          enable-deltas-report: true
+
+      - name: Upload size deltas report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-deltas-${{ matrix.board.alias }}
+          path: sketches-reports
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,30 @@ struct TrackConfig {
 Use the `real_track_data_debug` example to replay real NMEA data without GPS hardware.
 Track data from Orlando Kart Center is included. Compare results against MyLaps timing.
 
+## Continuous Integration
+
+GitHub Actions workflows live in `.github/workflows/`:
+
+- **arduino-lint.yml** — runs `arduino/arduino-lint-action@v2` at `compliance: specification`
+  (Library Manager compatibility level). Uploads `arduino-lint-report.json` as an artifact.
+- **compile-examples.yml** — uses `arduino/compile-sketches@v1` to compile every example
+  against a matrix of boards:
+  - `arduino:avr:mega` — all 3 examples
+  - `arduino:avr:uno` — `sector_timing_example` only (smoke test on small AVR; the other two
+    require `Serial1` which the Uno lacks)
+  - `esp32:esp32:esp32` — all 3 examples (custom platform URL pulls the ESP32 BSP)
+  - `Seeeduino:mbed:xiaonRF52840` — all 3 examples (recommended hardware, Seeed BSP URL)
+  - Pulled libs: ArxTypeTraits, Adafruit GPS Library, Adafruit GFX, Adafruit SSD1306,
+    Adafruit SH110X
+  - `enable-deltas-report: true` uploads `sketches-reports/` so PRs surface flash/SRAM deltas
+
+Both workflows trigger on push to `main`/`master`, on any PR, and manually via
+`workflow_dispatch`. Status badges are linked at the top of README.md.
+
+This is a **layer 1** CI setup — structural validation only (lint + compile). Future work:
+layer 2 (native unit tests for pure-math modules like `GeoMath`, `DirectionDetector`,
+`CourseDetector`) and layer 3 (NMEA replay regression tests against golden lap times).
+
 ## Cross-Reference: Related Repos
 
 - DovesLapTimer (this repo) - Core timing library

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Full datalogger + STL case files dropped over at [https://github.com/TheAngryRav
 Dataviewer: [https://github.com/TheAngryRaven/DovesDataViewer](https://github.com/TheAngryRaven/DovesDataViewer) (100% vibe code)
 
 # Doves GPS Lap Timer
+
+[![compile-examples](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml)
+[![arduino-lint](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml)
+
 Library for Arduino for creating damned accurate lap-timings using GPS data, on par with other commercial solutions.
 Once the driver is within a specified threshold of the line, it begins logging gps lat/lng/alt/speed.
 Once past the threshold, using the 4 points closest to the line, creates a catmullrom spline to interpolate the exact crossing time.


### PR DESCRIPTION
Adds structural CI for the library: arduino-lint validates library.properties
and project structure at Library Manager compliance level, and compile-examples
builds every example sketch across a board matrix (Mega, Uno, ESP32, XIAO
nRF52840). README gets two status badges; CLAUDE.md documents the setup
and notes layers 2/3 (native unit tests, NMEA replay regressions) as future
work.