### PR TITLE
ci: layer-2 host-native unit tests (43 tests across 4 suites)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,21 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  host-tests:
+    name: Host-native unit tests (g++)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show compiler version
+        run: g++ --version
+
+      - name: Build and run tests
+        working-directory: test
+        run: make run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,12 +319,27 @@ GitHub Actions workflows live in `.github/workflows/`:
     cell — the BSP's link recipe shells out to it even at compile-only time
   - `enable-deltas-report: true` uploads `sketches-reports/` so PRs surface flash/SRAM deltas
 
-Both workflows trigger on push to `main`/`master`, on any PR, and manually via
-`workflow_dispatch`. Status badges are linked at the top of README.md.
+- **unit-tests.yml** — builds and runs the host-native test suite in `test/`
+  on ubuntu-latest with `g++`. No board matrix; the suite is pure C++ and
+  doesn't depend on any Arduino toolchain. Fails the run on any failed assert.
 
-This is a **layer 1** CI setup — structural validation only (lint + compile). Future work:
-layer 2 (native unit tests for pure-math modules like `GeoMath`, `DirectionDetector`,
-`CourseDetector`) and layer 3 (NMEA replay regression tests against golden lap times).
+All three workflows trigger on push to `main`/`master`, on any PR, and
+manually via `workflow_dispatch`. Status badges are linked at the top of
+README.md.
+
+### Test layers
+
+- **Layer 1 — structural** (`arduino-lint.yml`, `compile-examples.yml`):
+  lint pass + every example compiles across the board matrix. Catches
+  missing includes, broken API signatures, fatal SRAM/flash overruns.
+- **Layer 2 — host unit tests** (`unit-tests.yml`): runs `test/` on the
+  host via `make run`. Covers `GeoMath`, `DirectionDetector`,
+  `CourseDetector` state machine, and a synthetic-track integration
+  pass over the full `DovesLapTimer` pipeline. Catches algorithm
+  regressions that compile fine but produce wrong numbers. See
+  `test/README.md` for layout and how to add a suite.
+- **Layer 3 — replay regression (future)**: feed real NMEA fixtures
+  through the lap timer and assert against MyLaps-confirmed golden times.
 
 ## Cross-Reference: Related Repos
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Dataviewer: [https://github.com/TheAngryRaven/DovesDataViewer](https://github.co
 
 [![compile-examples](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml)
 [![arduino-lint](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml)
+[![unit-tests](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/unit-tests.yml)
 
 Library for Arduino for creating damned accurate lap-timings using GPS data, on par with other commercial solutions.
 Once the driver is within a specified threshold of the line, it begins logging gps lat/lng/alt/speed.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,58 @@
+# Layer-2 host-native unit tests for DovesLapTimer.
+#
+# Each test_*.cpp builds into build/<name> and is run in sequence. Any
+# non-zero exit code fails the whole run.
+#
+# Usage:
+#   make            # build all tests
+#   make run        # build + run all tests
+#   make clean      # remove build artifacts
+#
+# Mock headers in mock/ are found before any (host-absent) Arduino headers
+# via the -Imock include path, so the library's #include <Arduino.h> /
+# #include "ArxTypeTraits.h" resolve to host-friendly stubs.
+
+CXX      ?= g++
+# -include mock/Arduino.h injects Arduino.h at the top of every TU, mirroring
+# what the Arduino IDE does automatically for .ino sketches and library .cpp
+# files. Without this, library sources that use F() / Stream / memset without
+# an explicit include fail to compile on the host.
+CXXFLAGS  = -std=c++14 -Wall -Wextra -O0 -g -Imock -I../src -include mock/Arduino.h
+LDFLAGS   =
+
+# Library sources we link into every test (small enough that always-link
+# costs nothing and we don't have to per-test bookkeep dependencies).
+LIB_SRCS = ../src/DovesLapTimer.cpp \
+           ../src/WaypointLapTimer.cpp \
+           ../src/CourseDetector.cpp \
+           ../src/CourseManager.cpp
+
+TEST_SRCS = $(wildcard test_*.cpp)
+TEST_BINS = $(TEST_SRCS:%.cpp=build/%)
+
+all: $(TEST_BINS)
+
+build/%: %.cpp $(LIB_SRCS) test_runner.h mock/Arduino.h mock/ArxTypeTraits.h
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LIB_SRCS) $(LDFLAGS)
+
+run: all
+	@failed=0; \
+	for bin in $(TEST_BINS); do \
+		echo ""; \
+		echo "Running $$bin"; \
+		echo "================================"; \
+		if ! $$bin; then failed=$$((failed + 1)); fi; \
+	done; \
+	echo ""; \
+	if [ $$failed -gt 0 ]; then \
+		echo "FAILED: $$failed test binary/binaries reported failures."; \
+		exit 1; \
+	else \
+		echo "All test binaries passed."; \
+	fi
+
+clean:
+	rm -rf build/
+
+.PHONY: all run clean

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,48 @@
+# Layer-2 unit tests
+
+Host-native unit tests for the pure-math and state-machine modules of
+DovesLapTimer. Compiles and runs on Linux / macOS with `g++` or `clang++`
+— no Arduino hardware, no emulator.
+
+## What's covered
+
+| Suite | Module(s) | Tests |
+|---|---|---|
+| `test_geomath` | `GeoMath.h` | haversine + haversine3D sanity, real distances |
+| `test_direction_detector` | `DirectionDetector` in `DovesLapTimer.h/cpp` | resolution outcomes, single-sector discard, glitch overwrite (CLAUDE.md issues #11 / #12), post-resolution lock |
+| `test_course_detector` | `CourseDetector.h/cpp` | full state machine + rejection cooldown (CLAUDE.md issue #13) |
+| `test_synthetic_track` | full `DovesLapTimer` pipeline | drives a deterministic 100m × 100m CCW square loop, asserts lap / sector times + cross-lap consistency + direction resolution |
+
+The synthetic-track suite is an integration test — if the crossing
+detection or interpolation regresses, lap-to-lap variance > 5ms or
+absolute timing drift > 100ms will fail the run.
+
+## Running locally
+
+```sh
+cd test
+make run        # build + run all suites; exits non-zero on any failure
+make clean      # remove build/
+```
+
+## How it works
+
+The Arduino IDE auto-injects `<Arduino.h>` at the top of every TU it
+compiles. On a host compiler that header doesn't exist, so `test/mock/`
+provides a tiny stub (`Stream` no-op, `F()` identity, `sq()` macro) plus
+a passthrough for `ArxTypeTraits.h` that just forwards to `<type_traits>`
+and `<utility>`.
+
+The Makefile force-injects the mock via `-include mock/Arduino.h`,
+mirroring the IDE's auto-include — no library source modifications needed.
+
+Each `test_*.cpp` declares plain test functions and lists them in `main()`
+via `RUN_TEST(name)`. `test_runner.h` provides `EXPECT_TRUE` /
+`EXPECT_EQ` / `EXPECT_NEAR` macros that record failures; each binary
+returns the failure count so the Makefile / CI can detect a red run.
+
+## Adding tests
+
+1. Write `test_<module>.cpp` with `void test_<name>()` functions.
+2. List each one in `main()` via `RUN_TEST(<name>)`.
+3. `make run` picks it up automatically (the Makefile globs `test_*.cpp`).

--- a/test/mock/Arduino.h
+++ b/test/mock/Arduino.h
@@ -1,0 +1,43 @@
+/**
+ * Host-build mock of Arduino.h for layer-2 unit tests.
+ *
+ * The library's Arduino surface is tiny — Stream, F(), and sq() — so this
+ * stub stays well under 100 lines. Debug print calls become no-ops on host
+ * so tests don't spew the library's verbose Serial output.
+ *
+ * Found via the test/ -I path before any real Arduino headers, which the
+ * host compiler doesn't have anyway.
+ */
+
+#ifndef ARDUINO_H
+#define ARDUINO_H
+
+#include <cstdint>
+#include <cstddef>
+#include <cmath>
+#include <cstring>
+#include <utility>
+
+#ifndef NULL
+#define NULL nullptr
+#endif
+
+// Arduino's F() macro stores string literals in flash on AVR. On host it
+// can be the identity — string literals already live in .rodata.
+#define F(s) (s)
+
+// Arduino's sq() macro. Library uses it in pointLineSegmentDistance.
+#define sq(x) ((x) * (x))
+
+// Minimal Stream stub. The library only ever calls print() / println()
+// through templated debug helpers, so accept anything and discard it.
+class Stream {
+public:
+  template <typename... Args>
+  void print(Args&&...) {}
+  template <typename... Args>
+  void println(Args&&...) {}
+  void println() {}
+};
+
+#endif

--- a/test/mock/ArxTypeTraits.h
+++ b/test/mock/ArxTypeTraits.h
@@ -1,0 +1,14 @@
+/**
+ * Host-build mock of ArxTypeTraits.h.
+ *
+ * ArxTypeTraits backports <type_traits> and <utility> to AVR toolchains
+ * that lack them. On a host compiler we just include the real STL headers.
+ */
+
+#ifndef ARX_TYPETRAITS_H
+#define ARX_TYPETRAITS_H
+
+#include <type_traits>
+#include <utility>
+
+#endif

--- a/test/test_course_detector.cpp
+++ b/test/test_course_detector.cpp
@@ -1,0 +1,225 @@
+/**
+ * Layer-2 tests for CourseDetector.
+ *
+ * Covers the state machine (IDLE → WAITING_FOR_SPEED → WAYPOINT_SET →
+ * CANDIDATES_READY → DETECTED), distance-based matching with tolerance,
+ * ranked output, and the rejection-cooldown behavior that fixes
+ * CLAUDE.md known-issue #13.
+ *
+ * All tests use a fixed lat/lng so geoHaversine returns 0 — we're testing
+ * the state machine, not the geo math.
+ */
+
+#include "test_runner.h"
+#include "../src/CourseDetector.h"
+
+static constexpr double WAYPOINT_LAT = 28.41265;
+static constexpr double WAYPOINT_LNG = -81.37970;
+static constexpr float  SPEED_FAST_KMH = 35.0f;   // ~21.7 mph, above 20mph gate
+static constexpr float  SPEED_SLOW_KMH = 10.0f;   // ~6.2 mph, below gate
+
+// =============================================================================
+// Initial state + IDLE -> WAITING_FOR_SPEED transition
+// =============================================================================
+
+void test_initial_state_is_idle() {
+  CourseDetector det;
+  EXPECT_EQ(det.getState(), DETECT_STATE_IDLE);
+  EXPECT_FALSE(det.hasWaypoint());
+  EXPECT_FALSE(det.isDetected());
+  EXPECT_EQ(det.getDetectedCourseIndex(), -1);
+  EXPECT_EQ(det.getRankedMatchCount(), 0);
+}
+
+void test_slow_speed_stays_waiting_for_speed() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_SLOW_KMH, 0.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAITING_FOR_SPEED);
+  EXPECT_FALSE(det.hasWaypoint());
+}
+
+// =============================================================================
+// WAITING_FOR_SPEED -> WAYPOINT_SET on speed threshold
+// =============================================================================
+
+void test_fast_speed_drops_waypoint() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);
+  EXPECT_TRUE(det.hasWaypoint());
+  EXPECT_NEAR(det.getWaypointLat(), WAYPOINT_LAT, 1e-9);
+  EXPECT_NEAR(det.getWaypointLng(), WAYPOINT_LNG, 1e-9);
+}
+
+// =============================================================================
+// WAYPOINT_SET state — proximity + min-distance gates
+// =============================================================================
+
+void test_proximity_without_min_distance_does_not_rank() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+
+  // 50m driven — proximity OK (same position), but distance < 200m gate
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 150.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);
+  EXPECT_EQ(det.getRankedMatchCount(), 0);
+}
+
+void test_min_distance_without_proximity_does_not_rank() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+
+  // 300m driven, but driver is 1km away from waypoint — no rank yet
+  det.update(WAYPOINT_LAT + 0.01, WAYPOINT_LNG, SPEED_FAST_KMH, 400.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);
+  EXPECT_EQ(det.getRankedMatchCount(), 0);
+}
+
+// =============================================================================
+// Course matching — distance vs lengthFt with 25% tolerance
+// =============================================================================
+
+void test_returning_to_waypoint_after_full_lap_ranks_match() {
+  // Course A is 1000ft (~305m). Drive ~305m and return -> exact match.
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+
+  // Drive 305m (1000ft), return to waypoint
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 405.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_CANDIDATES_READY);
+  EXPECT_EQ(det.getRankedMatchCount(), 1);
+  EXPECT_EQ(det.getRankedMatches()[0].index, 0);
+}
+
+void test_distance_outside_tolerance_does_not_match() {
+  // Course A is 1000ft (~305m). Drive 700m (~2296ft) — 129% off, way outside 25%.
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 800.0f);  // 700m driven
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);  // stays, no match
+  EXPECT_EQ(det.getRankedMatchCount(), 0);
+}
+
+void test_multiple_courses_sorted_by_match_quality() {
+  // Drive 305m (~1000ft). Three courses with varying distances from that.
+  // Best match should be Course B (1000ft), then A (900ft, 10% off),
+  // then C (1100ft, 10% off). D (1500ft) is outside tolerance.
+  CourseInfo courses[] = {
+    {"Course A",  900.0f},
+    {"Course B", 1000.0f},   // perfect match
+    {"Course C", 1100.0f},
+    {"Course D", 1500.0f},   // outside tolerance
+  };
+  CourseDetector det;
+  det.init(courses, 4);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 405.0f);  // ~305m
+
+  EXPECT_EQ(det.getState(), DETECT_STATE_CANDIDATES_READY);
+  EXPECT_EQ(det.getRankedMatchCount(), 3);  // D excluded
+  EXPECT_EQ(det.getRankedMatches()[0].index, 1);  // B first (lowest ratio)
+}
+
+// =============================================================================
+// Accept / reject transitions
+// =============================================================================
+
+void test_accept_candidate_moves_to_detected() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 405.0f);
+
+  det.acceptCandidate(0);
+  EXPECT_EQ(det.getState(), DETECT_STATE_DETECTED);
+  EXPECT_TRUE(det.isDetected());
+  EXPECT_EQ(det.getDetectedCourseIndex(), 0);
+}
+
+// =============================================================================
+// Rejection cooldown (CLAUDE.md known-issue #13)
+//
+// rejectAllCandidates(currentOdometer) must advance the waypoint odometer
+// to "now". Otherwise the driver is still inside proximity with
+// distanceSinceWaypoint above the 200m gate, so the next GPS fix
+// immediately re-ranks the same candidates — burning MAX_REJECTIONS in
+// a handful of frames and falling straight to Lap Anything.
+// =============================================================================
+
+void test_rejection_imposes_cooldown_until_another_full_lap() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 405.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_CANDIDATES_READY);
+
+  det.rejectAllCandidates(405.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);
+
+  // The very next GPS fix is still in proximity. Without the cooldown fix,
+  // distanceSinceWaypoint would still be 305m (above 200m gate) and we'd
+  // immediately re-rank.
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 410.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_WAYPOINT_SET);  // stays, NO re-rank
+  EXPECT_EQ(det.getRankedMatchCount(), 0);
+
+  // Drive another 300m+, return to waypoint — NOW we re-rank
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 715.0f);
+  EXPECT_EQ(det.getState(), DETECT_STATE_CANDIDATES_READY);
+}
+
+// =============================================================================
+// reset() restores initial state
+// =============================================================================
+
+void test_reset_restores_initial_state() {
+  CourseInfo courses[] = {{"Course A", 1000.0f}};
+  CourseDetector det;
+  det.init(courses, 1);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 100.0f);
+  det.update(WAYPOINT_LAT, WAYPOINT_LNG, SPEED_FAST_KMH, 405.0f);
+  det.acceptCandidate(0);
+  EXPECT_TRUE(det.isDetected());
+
+  det.reset();
+  EXPECT_EQ(det.getState(), DETECT_STATE_IDLE);
+  EXPECT_FALSE(det.isDetected());
+  EXPECT_EQ(det.getDetectedCourseIndex(), -1);
+}
+
+int main() {
+  printf("=== CourseDetector tests ===\n");
+
+  RUN_TEST(initial_state_is_idle);
+  RUN_TEST(slow_speed_stays_waiting_for_speed);
+  RUN_TEST(fast_speed_drops_waypoint);
+
+  RUN_TEST(proximity_without_min_distance_does_not_rank);
+  RUN_TEST(min_distance_without_proximity_does_not_rank);
+
+  RUN_TEST(returning_to_waypoint_after_full_lap_ranks_match);
+  RUN_TEST(distance_outside_tolerance_does_not_match);
+  RUN_TEST(multiple_courses_sorted_by_match_quality);
+
+  RUN_TEST(accept_candidate_moves_to_detected);
+  RUN_TEST(rejection_imposes_cooldown_until_another_full_lap);
+
+  RUN_TEST(reset_restores_initial_state);
+
+  TEST_SUMMARY();
+}

--- a/test/test_direction_detector.cpp
+++ b/test/test_direction_detector.cpp
@@ -1,0 +1,214 @@
+/**
+ * Layer-2 tests for DirectionDetector (struct in DovesLapTimer.h,
+ * onLineCrossing impl in DovesLapTimer.cpp).
+ *
+ * Covers initial state, both resolution outcomes, the single-sector
+ * discard window, glitch overwrite (CLAUDE.md known-issue #12), and the
+ * post-resolution lock. The two bugs at #11 and #12 would each be caught
+ * by the "forward_resolves_after_full_lap" / "glitch_overwrite_*" tests.
+ */
+
+#include "test_runner.h"
+#include "../src/DovesLapTimer.h"
+
+// =============================================================================
+// Initial state
+// =============================================================================
+
+void test_initial_state_is_unknown() {
+  DirectionDetector d;
+  EXPECT_EQ(d.direction, DIR_UNKNOWN);
+  EXPECT_FALSE(d.raceSeen);
+  EXPECT_EQ(d.lapS2CrossingTime, 0UL);
+  EXPECT_EQ(d.lapS3CrossingTime, 0UL);
+  EXPECT_FALSE(d.isResolved());
+  EXPECT_FALSE(d.isReverse());
+}
+
+void test_reset_restores_initial_state() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 100);
+  d.onLineCrossing(2, 200);
+  d.onLineCrossing(3, 300);
+  d.onLineCrossing(0, 400);  // resolves FORWARD
+  EXPECT_TRUE(d.isResolved());
+
+  d.reset();
+  EXPECT_EQ(d.direction, DIR_UNKNOWN);
+  EXPECT_FALSE(d.raceSeen);
+  EXPECT_EQ(d.lapS2CrossingTime, 0UL);
+  EXPECT_EQ(d.lapS3CrossingTime, 0UL);
+}
+
+// =============================================================================
+// raceSeen gating — sector crossings before the first S/F do nothing
+// =============================================================================
+
+void test_sector_crossing_before_raceseen_is_ignored() {
+  DirectionDetector d;
+  d.onLineCrossing(2, 1000);
+  d.onLineCrossing(3, 2000);
+  EXPECT_EQ(d.lapS2CrossingTime, 0UL);  // not recorded
+  EXPECT_EQ(d.lapS3CrossingTime, 0UL);
+  EXPECT_FALSE(d.isResolved());
+}
+
+void test_first_startfinish_arms_detection() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 5000);
+  EXPECT_TRUE(d.raceSeen);
+  EXPECT_FALSE(d.isResolved());  // can't resolve yet — no S2/S3 seen
+}
+
+// =============================================================================
+// Resolution from full lap (S/F → S2 → S3 → S/F or S/F → S3 → S2 → S/F)
+// =============================================================================
+
+void test_forward_resolves_after_full_lap() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);      // arm
+  d.onLineCrossing(2, 1000);
+  d.onLineCrossing(3, 2000);
+  d.onLineCrossing(0, 3000);   // resolve at next S/F
+  EXPECT_EQ(d.direction, DIR_FORWARD);
+  EXPECT_TRUE(d.isResolved());
+  EXPECT_FALSE(d.isReverse());
+}
+
+void test_reverse_resolves_after_full_lap() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(3, 1000);   // S3 first means driving the track backwards
+  d.onLineCrossing(2, 2000);
+  d.onLineCrossing(0, 3000);
+  EXPECT_EQ(d.direction, DIR_REVERSE);
+  EXPECT_TRUE(d.isReverse());
+}
+
+// =============================================================================
+// Single-sector lap discard (CLAUDE.md known-issue #11)
+//
+// If the driver crosses only one sector line in a lap (poorly-placed line,
+// or GPS sample rate too low to catch it), direction must NOT resolve from
+// that single data point. It used to lock as REVERSE from a lone S3.
+// =============================================================================
+
+void test_single_s2_lap_does_not_resolve() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(2, 1000);
+  // no S3 this lap
+  d.onLineCrossing(0, 3000);
+  EXPECT_EQ(d.direction, DIR_UNKNOWN);
+  // window must reset so next lap can try again
+  EXPECT_EQ(d.lapS2CrossingTime, 0UL);
+  EXPECT_EQ(d.lapS3CrossingTime, 0UL);
+}
+
+void test_single_s3_lap_does_not_resolve() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(3, 1000);
+  d.onLineCrossing(0, 3000);
+  EXPECT_EQ(d.direction, DIR_UNKNOWN);
+}
+
+void test_single_sector_lap_then_complete_lap_resolves() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(2, 1000);   // single-sector lap (discarded)
+  d.onLineCrossing(0, 3000);   // resolution fails, retries next lap
+  EXPECT_EQ(d.direction, DIR_UNKNOWN);
+
+  d.onLineCrossing(2, 4000);   // full lap this time
+  d.onLineCrossing(3, 5000);
+  d.onLineCrossing(0, 6000);
+  EXPECT_EQ(d.direction, DIR_FORWARD);
+}
+
+// =============================================================================
+// Glitch overwrite (CLAUDE.md known-issue #12)
+//
+// A GPS teleport that fabricates a phantom early sector crossing must be
+// overwritten by the real later crossing. Pre-fix, "first crossing wins"
+// locked direction to whatever the glitch said.
+// =============================================================================
+
+void test_glitch_s3_overwritten_by_real_s3_later() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(3, 100);    // phantom S3 glitch right after S/F
+  d.onLineCrossing(2, 1000);   // real S2 mid-lap
+  d.onLineCrossing(3, 2000);   // real S3 — must overwrite the phantom
+  d.onLineCrossing(0, 3000);
+  // Without overwrite: lapS3=100, lapS2=1000 → S2>S3 → REVERSE (wrong)
+  // With overwrite:    lapS3=2000, lapS2=1000 → S2<S3 → FORWARD (correct)
+  EXPECT_EQ(d.direction, DIR_FORWARD);
+}
+
+void test_glitch_s2_overwritten_by_real_s2_later() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(2, 100);    // phantom S2
+  d.onLineCrossing(3, 1000);
+  d.onLineCrossing(2, 2000);   // real S2 — overwrites phantom
+  d.onLineCrossing(0, 3000);
+  // lapS2=2000, lapS3=1000 → S2>S3 → REVERSE (correct, driver IS reverse)
+  EXPECT_EQ(d.direction, DIR_REVERSE);
+}
+
+// =============================================================================
+// Post-resolution lock
+// =============================================================================
+
+void test_direction_does_not_flip_after_resolution() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(2, 1000);
+  d.onLineCrossing(3, 2000);
+  d.onLineCrossing(0, 3000);   // FORWARD
+  EXPECT_EQ(d.direction, DIR_FORWARD);
+
+  // Subsequent crossings that look "reverse" must be ignored.
+  d.onLineCrossing(3, 4000);
+  d.onLineCrossing(2, 5000);
+  d.onLineCrossing(0, 6000);
+  EXPECT_EQ(d.direction, DIR_FORWARD);
+}
+
+void test_sector_crossings_ignored_after_resolution() {
+  DirectionDetector d;
+  d.onLineCrossing(0, 0);
+  d.onLineCrossing(2, 1000);
+  d.onLineCrossing(3, 2000);
+  d.onLineCrossing(0, 3000);   // FORWARD locked
+
+  d.onLineCrossing(2, 5000);
+  // After resolution the lap window is not maintained — S2 is no-op.
+  EXPECT_EQ(d.lapS2CrossingTime, 0UL);
+}
+
+int main() {
+  printf("=== DirectionDetector tests ===\n");
+
+  RUN_TEST(initial_state_is_unknown);
+  RUN_TEST(reset_restores_initial_state);
+
+  RUN_TEST(sector_crossing_before_raceseen_is_ignored);
+  RUN_TEST(first_startfinish_arms_detection);
+
+  RUN_TEST(forward_resolves_after_full_lap);
+  RUN_TEST(reverse_resolves_after_full_lap);
+
+  RUN_TEST(single_s2_lap_does_not_resolve);
+  RUN_TEST(single_s3_lap_does_not_resolve);
+  RUN_TEST(single_sector_lap_then_complete_lap_resolves);
+
+  RUN_TEST(glitch_s3_overwritten_by_real_s3_later);
+  RUN_TEST(glitch_s2_overwritten_by_real_s2_later);
+
+  RUN_TEST(direction_does_not_flip_after_resolution);
+  RUN_TEST(sector_crossings_ignored_after_resolution);
+
+  TEST_SUMMARY();
+}

--- a/test/test_geomath.cpp
+++ b/test/test_geomath.cpp
@@ -1,0 +1,112 @@
+/**
+ * Layer-2 tests for GeoMath.h (haversine + haversine3D).
+ *
+ * Pure math, no Arduino dependencies — proves the test infrastructure
+ * works before pulling in heavier modules.
+ */
+
+#include "test_runner.h"
+#include "../src/GeoMath.h"
+
+// =============================================================================
+// haversine — great-circle distance between two lat/lng points (meters)
+// =============================================================================
+
+void test_haversine_zero_distance() {
+  double d = geoHaversine(40.7128, -74.0060, 40.7128, -74.0060);
+  EXPECT_NEAR(d, 0.0, 0.001);
+}
+
+void test_haversine_nyc_to_la() {
+  // NYC (40.7128, -74.0060) -> LA (34.0522, -118.2437)
+  // Reference distance: ~3935.75 km
+  double d = geoHaversine(40.7128, -74.0060, 34.0522, -118.2437);
+  EXPECT_NEAR(d, 3935746.0, 5000.0);  // ±5km tolerance
+}
+
+void test_haversine_one_degree_latitude_at_equator() {
+  // 1° of latitude is ~111 km regardless of longitude
+  double d = geoHaversine(0.0, 0.0, 1.0, 0.0);
+  EXPECT_NEAR(d, 111195.0, 100.0);  // ±100m
+}
+
+void test_haversine_one_degree_longitude_at_equator() {
+  // At the equator, 1° of longitude is also ~111 km
+  double d = geoHaversine(0.0, 0.0, 0.0, 1.0);
+  EXPECT_NEAR(d, 111195.0, 100.0);
+}
+
+void test_haversine_one_degree_longitude_at_60deg_lat() {
+  // At 60° latitude, 1° of longitude is ~55.6 km (cos(60°) = 0.5)
+  double d = geoHaversine(60.0, 0.0, 60.0, 1.0);
+  EXPECT_NEAR(d, 55597.0, 100.0);
+}
+
+void test_haversine_small_distance_kart_scale() {
+  // 10m apart at Orlando Kart Center latitude.
+  // 0.0001° latitude ~= 11.1m.
+  double d = geoHaversine(28.4127, -81.3797, 28.4128, -81.3797);
+  EXPECT_NEAR(d, 11.12, 0.1);  // sub-meter precision
+}
+
+void test_haversine_symmetric() {
+  // distance(A, B) == distance(B, A)
+  double d1 = geoHaversine(28.4127, -81.3797, 28.4136, -81.3787);
+  double d2 = geoHaversine(28.4136, -81.3787, 28.4127, -81.3797);
+  EXPECT_NEAR(d1, d2, 1e-9);
+}
+
+// =============================================================================
+// haversine3D — distance including altitude delta (Pythagorean composition)
+// =============================================================================
+
+void test_haversine3d_zero_altitude_matches_2d() {
+  // Same altitude on both ends -> identical to haversine
+  double d3d = geoHaversine3D(28.4127, -81.3797, 50.0,
+                              28.4128, -81.3797, 50.0);
+  double d2d = geoHaversine(28.4127, -81.3797, 28.4128, -81.3797);
+  EXPECT_NEAR(d3d, d2d, 0.001);
+}
+
+void test_haversine3d_pure_vertical() {
+  // Same horizontal position, 10m altitude difference -> distance is 10m
+  double d = geoHaversine3D(28.4127, -81.3797, 50.0,
+                            28.4127, -81.3797, 60.0);
+  EXPECT_NEAR(d, 10.0, 0.001);
+}
+
+void test_haversine3d_diagonal() {
+  // 11.12m horizontal + 5m vertical -> sqrt(11.12² + 5²) ≈ 12.19m
+  double d = geoHaversine3D(28.4127, -81.3797, 50.0,
+                            28.4128, -81.3797, 55.0);
+  double expected = std::sqrt(11.12 * 11.12 + 5.0 * 5.0);
+  EXPECT_NEAR(d, expected, 0.1);
+}
+
+void test_haversine3d_altitude_drop_same_distance_as_climb() {
+  // sign of altitude delta shouldn't matter (squared in formula)
+  double climb = geoHaversine3D(28.4127, -81.3797, 50.0,
+                                28.4128, -81.3797, 60.0);
+  double drop  = geoHaversine3D(28.4127, -81.3797, 60.0,
+                                28.4128, -81.3797, 50.0);
+  EXPECT_NEAR(climb, drop, 1e-9);
+}
+
+int main() {
+  printf("=== GeoMath tests ===\n");
+
+  RUN_TEST(haversine_zero_distance);
+  RUN_TEST(haversine_nyc_to_la);
+  RUN_TEST(haversine_one_degree_latitude_at_equator);
+  RUN_TEST(haversine_one_degree_longitude_at_equator);
+  RUN_TEST(haversine_one_degree_longitude_at_60deg_lat);
+  RUN_TEST(haversine_small_distance_kart_scale);
+  RUN_TEST(haversine_symmetric);
+
+  RUN_TEST(haversine3d_zero_altitude_matches_2d);
+  RUN_TEST(haversine3d_pure_vertical);
+  RUN_TEST(haversine3d_diagonal);
+  RUN_TEST(haversine3d_altitude_drop_same_distance_as_climb);
+
+  TEST_SUMMARY();
+}

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -1,0 +1,76 @@
+/**
+ * Minimal test runner — hand-rolled, no framework dependency.
+ *
+ * Each test file defines plain functions and lists them in main() via
+ * RUN_TEST(name). EXPECT_* macros record failures; main() returns the
+ * failure count so make / CI can detect a red run.
+ */
+
+#ifndef TEST_RUNNER_H
+#define TEST_RUNNER_H
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+
+static int g_tests_run = 0;
+static int g_tests_failed = 0;
+static int g_current_test_failures = 0;
+
+#define RUN_TEST(name)                                          \
+  do {                                                          \
+    g_tests_run++;                                              \
+    g_current_test_failures = 0;                                \
+    printf("  %-50s ", #name);                                  \
+    fflush(stdout);                                             \
+    test_##name();                                              \
+    if (g_current_test_failures > 0) {                          \
+      printf(" FAIL\n");                                        \
+      g_tests_failed++;                                         \
+    } else {                                                    \
+      printf(" ok\n");                                          \
+    }                                                           \
+  } while (0)
+
+#define EXPECT_TRUE(cond)                                       \
+  do {                                                          \
+    if (!(cond)) {                                              \
+      printf("\n    EXPECT_TRUE failed: %s  (line %d)",         \
+             #cond, __LINE__);                                  \
+      g_current_test_failures++;                                \
+    }                                                           \
+  } while (0)
+
+#define EXPECT_FALSE(cond) EXPECT_TRUE(!(cond))
+
+#define EXPECT_EQ(a, b)                                         \
+  do {                                                          \
+    auto _aval = (a);                                           \
+    auto _bval = (b);                                           \
+    if (!(_aval == _bval)) {                                    \
+      printf("\n    EXPECT_EQ failed: %s == %s  (line %d)",     \
+             #a, #b, __LINE__);                                 \
+      g_current_test_failures++;                                \
+    }                                                           \
+  } while (0)
+
+#define EXPECT_NEAR(a, b, tol)                                  \
+  do {                                                          \
+    double _aval = (double)(a);                                 \
+    double _bval = (double)(b);                                 \
+    double _tval = (double)(tol);                               \
+    if (std::fabs(_aval - _bval) > _tval) {                     \
+      printf("\n    EXPECT_NEAR failed: |%g - %g| > %g  (line %d)",\
+             _aval, _bval, _tval, __LINE__);                    \
+      g_current_test_failures++;                                \
+    }                                                           \
+  } while (0)
+
+#define TEST_SUMMARY()                                          \
+  do {                                                          \
+    printf("\n%d tests run, %d failed.\n",                      \
+           g_tests_run, g_tests_failed);                        \
+    return g_tests_failed > 0 ? 1 : 0;                          \
+  } while (0)
+
+#endif

--- a/test/test_synthetic_track.cpp
+++ b/test/test_synthetic_track.cpp
@@ -1,0 +1,274 @@
+/**
+ * Layer-2 integration test for the full DovesLapTimer pipeline.
+ *
+ * Drives the lap timer through a deterministic synthetic track — the same
+ * 100m × 100m counter-clockwise square used by sector_timing_example —
+ * and asserts:
+ *
+ *   - 3 laps complete
+ *   - lap times match expected (80 steps × 200ms = 16000ms)
+ *   - sector times match expected (20 steps × 200ms = 4000ms each)
+ *   - laps are identical lap-to-lap (deterministic interpolation)
+ *   - sum of sectors ≈ lap time
+ *   - direction resolves to FORWARD
+ *   - optimal lap ≈ best lap (since every lap is the same)
+ *
+ * If the crossing-detection / interpolation algorithm regresses, the
+ * cross-lap consistency check will flag it before anyone notices in real
+ * data.
+ */
+
+#include "test_runner.h"
+#include "../src/DovesLapTimer.h"
+
+// =============================================================================
+// Synthetic track (mirrors examples/sector_timing_example)
+// =============================================================================
+
+static constexpr double TRACK_SOUTH_LAT = 28.41265;
+static constexpr double TRACK_NORTH_LAT = 28.41355;
+static constexpr double TRACK_WEST_LNG  = -81.37970;
+static constexpr double TRACK_EAST_LNG  = -81.37870;
+static constexpr unsigned int  STEPS_PER_LAP   = 80;
+static constexpr unsigned long SIM_MS_PER_STEP = 200;
+static constexpr float         SIM_SPEED_KNOTS = 48.0f;
+static constexpr float         SIM_ALT_METERS  = 50.0f;
+
+static constexpr double SF_A_LAT = 28.41255, SF_A_LNG = -81.37920;
+static constexpr double SF_B_LAT = 28.41275, SF_B_LNG = -81.37920;
+static constexpr double S2_A_LAT = 28.41310, S2_A_LNG = -81.37860;
+static constexpr double S2_B_LAT = 28.41310, S2_B_LNG = -81.37880;
+static constexpr double S3_A_LAT = 28.41345, S3_A_LNG = -81.37925;
+static constexpr double S3_B_LAT = 28.41365, S3_B_LNG = -81.37925;
+
+static void generateSyntheticFix(unsigned long step, double &lat, double &lng) {
+  const unsigned int sideSteps = STEPS_PER_LAP / 4;
+  const unsigned int phase = step % STEPS_PER_LAP;
+  const double t = (phase % sideSteps) / (double)sideSteps;
+
+  if (phase < sideSteps) {
+    lat = TRACK_SOUTH_LAT;
+    lng = TRACK_WEST_LNG + t * (TRACK_EAST_LNG - TRACK_WEST_LNG);
+  } else if (phase < 2 * sideSteps) {
+    lat = TRACK_SOUTH_LAT + t * (TRACK_NORTH_LAT - TRACK_SOUTH_LAT);
+    lng = TRACK_EAST_LNG;
+  } else if (phase < 3 * sideSteps) {
+    lat = TRACK_NORTH_LAT;
+    lng = TRACK_EAST_LNG + t * (TRACK_WEST_LNG - TRACK_EAST_LNG);
+  } else {
+    lat = TRACK_NORTH_LAT + t * (TRACK_SOUTH_LAT - TRACK_NORTH_LAT);
+    lng = TRACK_WEST_LNG;
+  }
+}
+
+// =============================================================================
+// Drive the lap timer through N simulated laps.
+//
+// Captures per-lap completion times via a callback-like accumulator so we
+// can assert lap-to-lap consistency, not just final state.
+// =============================================================================
+
+struct LapRecord {
+  unsigned long lapTime;
+  unsigned long sector1;
+  unsigned long sector2;
+  // sector3 is only set briefly inside loop() and reset before we can
+  // observe it externally — covered separately via getBestSector3Time().
+};
+
+static void driveLaps(DovesLapTimer &timer, int targetLaps,
+                      LapRecord *records) {
+  unsigned long simTimeMs = 0;
+  int lastLapCount = 0;
+  int lastSector = 0;
+  int recIdx = 0;
+  // Generous step ceiling so a bug that fails to detect crossings can't
+  // hang the test forever.
+  const unsigned long maxSteps = STEPS_PER_LAP * (unsigned long)(targetLaps + 2) + 50;
+
+  for (unsigned long step = 0; step < maxSteps; step++) {
+    double lat, lng;
+    generateSyntheticFix(step, lat, lng);
+    timer.updateCurrentTime(simTimeMs);
+    timer.loop(lat, lng, SIM_ALT_METERS, SIM_SPEED_KNOTS);
+
+    int sector = timer.getCurrentSector();
+    int laps = timer.getLaps();
+
+    // Snapshot sector1 / sector2 the moment they finish, while they're
+    // still in the current-lap accumulators.
+    if (sector != lastSector && recIdx < targetLaps) {
+      if (lastSector == 1) {
+        records[recIdx].sector1 = timer.getCurrentLapSector1Time();
+      } else if (lastSector == 2) {
+        records[recIdx].sector2 = timer.getCurrentLapSector2Time();
+      }
+    }
+    lastSector = sector;
+
+    if (laps > lastLapCount && recIdx < targetLaps) {
+      records[recIdx].lapTime = timer.getLastLapTime();
+      recIdx++;
+      lastLapCount = laps;
+    }
+
+    simTimeMs += SIM_MS_PER_STEP;
+    if (laps >= targetLaps) break;
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+void test_three_laps_complete() {
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_EQ(timer.getLaps(), 3);
+  EXPECT_TRUE(timer.getRaceStarted());
+}
+
+void test_lap_time_matches_expected() {
+  // Expected: 80 steps × 200ms = 16000ms. Allow 100ms slack for
+  // interpolation jitter at the crossing.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_NEAR(records[0].lapTime, 16000UL, 100.0);
+  EXPECT_NEAR(records[1].lapTime, 16000UL, 100.0);
+  EXPECT_NEAR(records[2].lapTime, 16000UL, 100.0);
+}
+
+void test_lap_times_are_deterministic_across_laps() {
+  // The synthetic track is deterministic — every lap should produce
+  // identical times. Variance > 5ms means interpolation is unstable.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_NEAR(records[0].lapTime, records[1].lapTime, 5.0);
+  EXPECT_NEAR(records[1].lapTime, records[2].lapTime, 5.0);
+}
+
+void test_sector_times_match_expected() {
+  // The synthetic track's sector lines are not evenly spaced around the
+  // loop — S3 sits at lng=-81.37925 on the north side and S/F at
+  // lng=-81.37920 on the south side, so sector 3 wraps the entire west
+  // side plus half the south side. Expected step counts per sector
+  // (each step = 200ms sim time):
+  //   Sector 1 (S/F → S2):  ~20 steps = 4000ms
+  //   Sector 2 (S2 → S3):   ~21 steps = 4200ms
+  //   Sector 3 (S3 → S/F):  ~39 steps = 7800ms
+  //   Total:                  80 steps = 16000ms
+  // Sectors 1 and 2 captured per-lap via mid-lap snapshotting.
+  // Sector 3 only verified via getBestSector3Time() since it's reset
+  // inside the lap-completing loop() call before we can observe it.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_NEAR(records[1].sector1, 4000UL, 100.0);
+  EXPECT_NEAR(records[1].sector2, 4200UL, 100.0);
+  EXPECT_NEAR(timer.getBestSector3Time(), 7800UL, 100.0);
+}
+
+void test_sectors_are_deterministic_across_laps() {
+  // All laps identical -> sector1/sector2 values should match across laps.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_NEAR(records[0].sector1, records[1].sector1, 5.0);
+  EXPECT_NEAR(records[1].sector1, records[2].sector1, 5.0);
+  EXPECT_NEAR(records[0].sector2, records[1].sector2, 5.0);
+  EXPECT_NEAR(records[1].sector2, records[2].sector2, 5.0);
+}
+
+void test_sectors_sum_to_lap_time() {
+  // Best sector1 + best sector2 + best sector3 should match best lap
+  // time (all laps identical so best == any lap, and sectors of any lap
+  // cover the whole lap).
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  unsigned long sectorSum = timer.getBestSector1Time()
+                          + timer.getBestSector2Time()
+                          + timer.getBestSector3Time();
+  EXPECT_NEAR(sectorSum, timer.getBestLapTime(), 5.0);
+}
+
+void test_optimal_lap_close_to_best_lap_on_uniform_track() {
+  // Every lap is identical -> best sector times all come from the same
+  // lap -> optimal lap = best lap (within rounding).
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  unsigned long optimal = timer.getOptimalLapTime();
+  unsigned long best = timer.getBestLapTime();
+  EXPECT_TRUE(optimal > 0);
+  EXPECT_TRUE(best > 0);
+  EXPECT_NEAR(optimal, best, 5.0);
+}
+
+void test_direction_resolves_to_forward() {
+  // S/F line is set up so a CCW driver hits sectors in 2→3 order,
+  // which is "forward" by the detector's S2<S3 rule.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+  timer.setSector2Line(S2_A_LAT, S2_A_LNG, S2_B_LAT, S2_B_LNG);
+  timer.setSector3Line(S3_A_LAT, S3_A_LNG, S3_B_LAT, S3_B_LNG);
+
+  LapRecord records[3];
+  driveLaps(timer, 3, records);
+
+  EXPECT_TRUE(timer.isDirectionResolved());
+  EXPECT_EQ(timer.getDirection(), DIR_FORWARD);
+}
+
+int main() {
+  printf("=== Synthetic track integration tests ===\n");
+
+  RUN_TEST(three_laps_complete);
+  RUN_TEST(lap_time_matches_expected);
+  RUN_TEST(lap_times_are_deterministic_across_laps);
+  RUN_TEST(sector_times_match_expected);
+  RUN_TEST(sectors_are_deterministic_across_laps);
+  RUN_TEST(sectors_sum_to_lap_time);
+  RUN_TEST(optimal_lap_close_to_best_lap_on_uniform_track);
+  RUN_TEST(direction_resolves_to_forward);
+
+  TEST_SUMMARY();
+}


### PR DESCRIPTION
## Summary

Adds a `test/` directory with **43 host-native tests** across 4 suites, wired into CI as a third workflow (`unit-tests.yml`). Compiles and runs on Linux/macOS with plain `g++` — no Arduino toolchain or hardware needed.

| Suite | Module(s) | Tests |
|---|---|---|
| `test_geomath` | `GeoMath.h` | 11 |
| `test_direction_detector` | `DirectionDetector` | 13 |
| `test_course_detector` | `CourseDetector` | 11 |
| `test_synthetic_track` | full `DovesLapTimer` pipeline | 8 |

The detector suites explicitly cover the bugs at CLAUDE.md issues **#11**, **#12**, and **#13** — they're the regression net so those don't sneak back.

The synthetic-track suite drives the full lap-timer pipeline through a deterministic 100m × 100m CCW square loop and asserts:
- 3 laps complete
- lap time = 16000ms (80 steps × 200ms)
- sectors 1/2/3 = 4000ms / 4200ms / 7800ms (asymmetric because the example's S3 line happens to wrap most of the perimeter — documented in the test)
- cross-lap consistency within 5ms (deterministic interpolation)
- direction resolves to `DIR_FORWARD`

## Infrastructure

- `test/mock/{Arduino.h,ArxTypeTraits.h}` stub the tiny Arduino surface the library actually uses (`Stream`, `F()`, `sq()`) and forward to STL on the host
- Force-injected via `-include` in the Makefile, mirroring what the Arduino IDE does for `.ino` sketches — **no library source modifications needed**
- `test_runner.h`: hand-rolled `RUN_TEST` / `EXPECT_*` macros, zero deps — pedagogical over fancy
- `Makefile` globs `test_*.cpp`, builds each into its own binary, runs in sequence, returns non-zero on any failure
- New `unit-tests.yml` workflow runs on push/PR/dispatch
- README gets a third CI badge
- CLAUDE.md gets a new "Test layers" section explaining the 1/2/3 philosophy

## Test plan

- [x] All 43 tests pass locally on `g++ 13.x`
- [ ] CI `unit-tests` workflow shows green on this PR
- [ ] The two existing workflows (arduino-lint, compile-examples) still pass — nothing in `src/` or `examples/` changed

## Local

```sh
cd test
make run
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013qWRPdunkyPAKxt1NDVCKo)_