### PR TITLE
catmull-rom: characterize lat/lng-only scope, tighten replay tolerances 50ms→10ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,15 @@ struct TrackConfig {
 
 ## Known Issues & TODOs (from code comments)
 
-1. ~~**Catmull-Rom interpolation bug**~~: Fixed - spline now only used for lat/lng (not time/odometer), and previous GPS fix inserted as pre-crossing control point
+1. ~~**Catmull-Rom interpolation bug**~~: Fixed - spline is now used **only for the
+   reported crossing point's lat/lng**. Time and odometer are always interpolated
+   linearly to avoid spline overshoot producing wrong lap times. Practical consequence:
+   `forceCatmullRomInterpolation()` does NOT change lap-time output vs. linear — it
+   only affects `crossingLat`/`crossingLng` (which the public API doesn't currently
+   expose). The mode setting is preserved for future API additions and for users who
+   inspect interpolated coords via debug logs; layer-3 replay tests assert
+   `catmull_lap_times == linear_lap_times` on all four real-track fixtures to keep
+   this contract enforced.
 2. **Altitude messing up distance**: `loop()` has a TODO: "I think alt is messing up, investigate more... maybe flag?"
 3. ~~**Early abort bug**~~: Abandoned — commented-out `crossingStartedLineSide` tracking plus the `CROSSING_LINE_SIDE_NONE` define have been removed; the underlying "abort early" optimization was never implemented and the current hypotenuse-threshold flow is reliable in practice.
 4. **`checkStartFinish` portability**: TODO at the top of `checkStartFinish` to make more portable for split timing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dataviewer: [https://github.com/TheAngryRaven/DovesDataViewer](https://github.co
 
 Library for Arduino for creating damned accurate lap-timings using GPS data, on par with other commercial solutions.
 Once the driver is within a specified threshold of the line, it begins logging gps lat/lng/alt/speed.
-Once past the threshold, using the 4 points closest to the line, creates a catmullrom spline to interpolate the exact crossing time.
+Once past the threshold, the 4 points closest to the line are used to interpolate the exact crossing — see [Interpolation modes](#interpolation-modes) below for the linear vs. Catmull-Rom trade-off.
 
 ## What's New in v4.0
 
@@ -104,6 +104,19 @@ CourseManager (orchestrator - optional, use for multi-course tracks)
 
 You can still use `DovesLapTimer` standalone if you only have one course and know your crossing lines up front. `CourseManager` is for when you want automatic course detection and multi-course support.
 
+## Interpolation modes
+
+When the driver exits the crossing zone, the library has a buffer of GPS fixes
+straddling the line and needs to compute the exact crossing time + position.
+Two modes are available:
+
+| | Affects lap time? | Affects crossing-point coords? | When to use |
+|---|---|---|---|
+| `forceLinearInterpolation()` *(default)* | yes — linear blend by distance + speed | yes — straight-line blend | Always works. The right default for kart timing — sub-10ms regression-tested against real fixtures. |
+| `forceCatmullRomInterpolation()` | **no** — falls back to linear for time/odometer | yes — smooth spline if 4 control points available, else linear | Useful only if you care about the reported crossing lat/lng coords (e.g. plotting where on the line you crossed). Lap-time output is identical to linear. |
+
+**Important context**: Catmull-Rom used to interpolate everything including time, but spline overshoot occasionally produced wrong lap times. The fix limited the spline to lat/lng of the crossing point — time and odometer are always linear. So switching modes has no effect on `getLastLapTime()` / `getBestLapTime()` / sector times. If you only care about timing, leave the default alone.
+
 ## API
 
 ### Option 1: DovesLapTimer (standalone, single course)
@@ -136,10 +149,10 @@ The code should have clarifying comments wherever there are any unclear bits.
   lapTimer.setSector2Line(sector2PointALat, sector2PointALng, sector2PointBLat, sector2PointBLng);
   lapTimer.setSector3Line(sector3PointALat, sector3PointALng, sector3PointBLat, sector3PointBLng);
 
-  // default interpolation method
-  lapTimer.forceCatmullRomInterpolation();
-  // Might be more accurate if your finishline is on a location you expect constant speed
-  lapTimer.forceLinearInterpolation();
+  // Linear is the default — call one of these only if you want to switch.
+  // See "Interpolation modes" below for what each one actually changes.
+  lapTimer.forceLinearInterpolation();      // default
+  lapTimer.forceCatmullRomInterpolation();  // smoother crossing-point coords; lap time unchanged
   // reset all counters back to zero
   lapTimer.reset();
 

--- a/test/test_nmea_2laps.cpp
+++ b/test/test_nmea_2laps.cpp
@@ -2,17 +2,21 @@
  * Layer-3 NMEA replay regression test.
  *
  * Fixture: examples/real_track_data_debug/gps_race_data_2laps.h
- *   Orlando Kart Center, two laps, white Tony rental.
+ *   Orlando Kart Center, two laps, white Tony rental. (Recording actually
+ *   continues a few seconds into a third lap.)
  *
- * Golden times (from fixture header):
- *   LAP 1
- *     DoveTimer LINEAR  : 1:09.958 ms (69958)
- *     DoveTimer CATMULL : 1:09.942 ms (69942)
- *     MyLaps            : not recorded
- *   LAP 2
- *     MyLaps            : 1:08.807 ms (68807) — magnetic-loop ground truth
- *     DoveTimer LINEAR  : 1:08.748 ms (68748)
- *     DoveTimer CATMULL : 1:08.745 ms (68745)
+ * Golden times (current library output, captured 2026-05-21):
+ *   LAP 1: 69961 ms (linear == catmull)
+ *   LAP 2: 68742 ms (linear == catmull)
+ *
+ * Lap times are identical between modes because Catmull-Rom is scoped to
+ * crossing-point lat/lng only — time/odometer are always interpolated
+ * linearly (CLAUDE.md known-issue #1). Fixture-header values from
+ * pre-2026 captures (LINEAR 69958/68748, CATMULL 69942/68745) predate
+ * that scope fix and no longer represent current behavior.
+ *
+ * MyLaps magnetic-loop ground truth on LAP 2: 68807 ms — checked with
+ * a looser ±200ms bound.
  */
 
 #include "test_runner.h"
@@ -30,8 +34,6 @@ static ReplayConfig makeCfg(bool catmull) {
 }
 
 void test_linear_completes_two_laps() {
-  // Fixture is named "two laps" but the recording continues a few seconds
-  // into a third lap. Golden values only cover laps 1 and 2 — assert >= 2.
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE((int)r.lapTimes.size() >= 2);
 }
@@ -39,13 +41,13 @@ void test_linear_completes_two_laps() {
 void test_linear_lap1_matches_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 69958UL, 50.0);
+  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 69961UL, 10.0);
 }
 
 void test_linear_lap2_matches_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE(r.lapTimes.size() >= 2);
-  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 68748UL, 50.0);
+  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 68742UL, 10.0);
 }
 
 void test_linear_lap2_close_to_mylaps() {
@@ -62,19 +64,23 @@ void test_catmull_completes_two_laps() {
 void test_catmull_lap1_matches_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
   EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 69942UL, 50.0);
+  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 69961UL, 10.0);
 }
 
 void test_catmull_lap2_matches_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
   EXPECT_TRUE(r.lapTimes.size() >= 2);
-  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 68745UL, 50.0);
+  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 68742UL, 10.0);
 }
 
-void test_catmull_lap2_close_to_mylaps() {
-  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
-  EXPECT_TRUE(r.lapTimes.size() >= 2);
-  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 68807UL, 200.0);
+void test_catmull_lap_times_match_linear() {
+  ReplayResult lin = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
+  ReplayResult cat = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
+  EXPECT_TRUE(lin.lapTimes.size() >= 2 && cat.lapTimes.size() >= 2);
+  if (lin.lapTimes.size() >= 2 && cat.lapTimes.size() >= 2) {
+    EXPECT_EQ(cat.lapTimes[0], lin.lapTimes[0]);
+    EXPECT_EQ(cat.lapTimes[1], lin.lapTimes[1]);
+  }
 }
 
 int main() {
@@ -88,7 +94,7 @@ int main() {
   RUN_TEST(catmull_completes_two_laps);
   RUN_TEST(catmull_lap1_matches_golden);
   RUN_TEST(catmull_lap2_matches_golden);
-  RUN_TEST(catmull_lap2_close_to_mylaps);
+  RUN_TEST(catmull_lap_times_match_linear);
 
   TEST_SUMMARY();
 }

--- a/test/test_nmea_lap.cpp
+++ b/test/test_nmea_lap.cpp
@@ -4,15 +4,18 @@
  * Fixture: examples/real_track_data_debug/gps_race_data_lap.h
  *   Orlando Kart Center, 4/29/23, one lap, white Tony rental.
  *
- * Golden times (from fixture header):
- *   MyLaps    : 1:08.807 ms (68807) — magnetic-loop ground truth
- *   DoveTimer : 1:08.748 ms (68748) — LINEAR interpolation
- *   DoveTimer : 1:08.745 ms (68745) — CATMULL-ROM interpolation
+ * Golden times (current library output, captured 2026-05-21):
+ *   Linear  : 68742 ms (1:08.742)
+ *   Catmull : 68742 ms — identical to linear; the spline interpolation
+ *             is intentionally scoped to crossing-point lat/lng only,
+ *             so lap times are always linear-interpolated regardless
+ *             of mode (see CLAUDE.md known-issue #1).
  *
- * The pinned 68748 / 68745 values are this library's previously verified
- * outputs — tight tolerance catches algorithm regressions. The 68807
- * MyLaps value is the actual on-track ground truth — looser tolerance
- * proves we're still close to reality.
+ * Fixture-header values (1:08.748 linear, 1:08.745 catmull) are from
+ * pre-2026 captures before the spline-scope fix and no longer represent
+ * current behavior. MyLaps magnetic-loop ground truth (1:08.807) is
+ * still useful as a sanity bound (within ±200ms is great for GPS vs.
+ * a buried magnet).
  */
 
 #include "test_runner.h"
@@ -44,12 +47,11 @@ void test_linear_completes_one_lap() {
   EXPECT_EQ((int)r.lapTimes.size(), 1);
 }
 
-void test_linear_matches_dovetimer_golden() {
+void test_linear_matches_pinned_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
-  // Documented: DoveTimer LINEAR = 1:08.748 = 68748 ms
   EXPECT_TRUE(r.lapTimes.size() >= 1);
   if (r.lapTimes.size() >= 1) {
-    EXPECT_NEAR(r.lapTimes[0], 68748UL, 50.0);
+    EXPECT_NEAR(r.lapTimes[0], 68742UL, 10.0);
   }
 }
 
@@ -66,6 +68,9 @@ void test_linear_close_to_mylaps() {
 
 // =============================================================================
 // CATMULL-ROM interpolation
+//
+// Identical lap times to linear (spline scope is lat/lng-only). These tests
+// still exercise the alternate code path to keep it from rotting.
 // =============================================================================
 
 void test_catmull_completes_one_lap() {
@@ -74,20 +79,21 @@ void test_catmull_completes_one_lap() {
   EXPECT_EQ((int)r.lapTimes.size(), 1);
 }
 
-void test_catmull_matches_dovetimer_golden() {
+void test_catmull_matches_pinned_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
-  // Documented: DoveTimer CATMULL = 1:08.745 = 68745 ms
   EXPECT_TRUE(r.lapTimes.size() >= 1);
   if (r.lapTimes.size() >= 1) {
-    EXPECT_NEAR(r.lapTimes[0], 68745UL, 50.0);
+    EXPECT_NEAR(r.lapTimes[0], 68742UL, 10.0);
   }
 }
 
-void test_catmull_close_to_mylaps() {
-  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
-  EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) {
-    EXPECT_NEAR(r.lapTimes[0], 68807UL, 200.0);
+void test_catmull_lap_time_matches_linear() {
+  ReplayResult lin = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
+  ReplayResult cat = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
+  EXPECT_TRUE(lin.lapTimes.size() >= 1 && cat.lapTimes.size() >= 1);
+  if (lin.lapTimes.size() >= 1 && cat.lapTimes.size() >= 1) {
+    // Spline is scoped to crossing-point lat/lng only -> lap times must match.
+    EXPECT_EQ(cat.lapTimes[0], lin.lapTimes[0]);
   }
 }
 
@@ -95,12 +101,12 @@ int main() {
   printf("=== NMEA replay: OKC single lap (gps_race_data_lap.h) ===\n");
 
   RUN_TEST(linear_completes_one_lap);
-  RUN_TEST(linear_matches_dovetimer_golden);
+  RUN_TEST(linear_matches_pinned_golden);
   RUN_TEST(linear_close_to_mylaps);
 
   RUN_TEST(catmull_completes_one_lap);
-  RUN_TEST(catmull_matches_dovetimer_golden);
-  RUN_TEST(catmull_close_to_mylaps);
+  RUN_TEST(catmull_matches_pinned_golden);
+  RUN_TEST(catmull_lap_time_matches_linear);
 
   TEST_SUMMARY();
 }

--- a/test/test_nmea_long_lap.cpp
+++ b/test/test_nmea_long_lap.cpp
@@ -4,14 +4,14 @@
  * Fixture: examples/real_track_data_debug/gps_race_data_long_lap.h
  *   Orlando Kart Center pro track (long course), single lap, Praga.
  *
- * Golden times (from fixture header):
- *   DoveTimer LINEAR  : 0:58.611 ms (58611)
- *   DoveTimer CATMULL : 0:58.611 ms (58611)
- *   MyLaps            : not recorded
+ * Golden times (current library output, captured 2026-05-21):
+ *   Linear  : 58614 ms (0:58.614)
+ *   Catmull : 58614 ms — see CLAUDE.md known-issue #1 for why mode
+ *             doesn't affect lap time.
  *
- * Note: linear and Catmull-Rom report identical times for this fixture,
- * which suggests the crossing happens at a point where the four spline
- * control points produce a near-linear interpolant — useful side check.
+ * Fixture-header value (0:58.611) is a 3ms drift, likely from minor
+ * refinement of the linear interpolation since the original capture.
+ * No MyLaps ground truth for this lap.
  */
 
 #include "test_runner.h"
@@ -33,10 +33,10 @@ void test_linear_completes_one_lap() {
   EXPECT_EQ((int)r.lapTimes.size(), 1);
 }
 
-void test_linear_matches_golden() {
+void test_linear_matches_pinned_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 58611UL, 50.0);
+  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 58614UL, 10.0);
 }
 
 void test_catmull_completes_one_lap() {
@@ -44,20 +44,30 @@ void test_catmull_completes_one_lap() {
   EXPECT_EQ((int)r.lapTimes.size(), 1);
 }
 
-void test_catmull_matches_golden() {
+void test_catmull_matches_pinned_golden() {
   ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
   EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 58611UL, 50.0);
+  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 58614UL, 10.0);
+}
+
+void test_catmull_lap_time_matches_linear() {
+  ReplayResult lin = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
+  ReplayResult cat = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
+  EXPECT_TRUE(lin.lapTimes.size() >= 1 && cat.lapTimes.size() >= 1);
+  if (lin.lapTimes.size() >= 1 && cat.lapTimes.size() >= 1) {
+    EXPECT_EQ(cat.lapTimes[0], lin.lapTimes[0]);
+  }
 }
 
 int main() {
   printf("=== NMEA replay: OKC long lap (gps_race_data_long_lap.h) ===\n");
 
   RUN_TEST(linear_completes_one_lap);
-  RUN_TEST(linear_matches_golden);
+  RUN_TEST(linear_matches_pinned_golden);
 
   RUN_TEST(catmull_completes_one_lap);
-  RUN_TEST(catmull_matches_golden);
+  RUN_TEST(catmull_matches_pinned_golden);
+  RUN_TEST(catmull_lap_time_matches_linear);
 
   TEST_SUMMARY();
 }

--- a/test/test_nmea_praga.cpp
+++ b/test/test_nmea_praga.cpp
@@ -4,13 +4,16 @@
  * Fixture: examples/real_track_data_debug/gps_race_data_praga_laps.h
  *   Orlando Kart Center, two laps, Praga Dark with blown Tillotson motor.
  *
- * Golden times (from fixture header):
- *   LAP 1: DoveTimer LINEAR  : 1:02.727 ms (62727)
- *   LAP 2: DoveTimer LINEAR  : 1:01.317 ms (61317)
- *   MyLaps / CATMULL : not recorded
+ * Golden times (current library output, captured 2026-05-21):
+ *   LAP 1: 62726 ms — linear == catmull
+ *   LAP 2: 61319 ms — linear == catmull
  *
- * Only the LINEAR path is tested — the fixture predates the CATMULL
- * baseline being captured.
+ * Fixture-header values (LAP 1 LINEAR 62727, LAP 2 LINEAR 61317) drift by
+ * 1-2 ms — minor linear-interpolation refinement since original capture.
+ * No MyLaps or Catmull-Rom baseline was recorded for this fixture; we
+ * exercise both modes here for code-path coverage, and assert they agree
+ * (per CLAUDE.md known-issue #1: spline is scoped to lat/lng only, so
+ * lap times are mode-independent).
  */
 
 #include "test_runner.h"
@@ -19,37 +22,48 @@
 
 static const int num_gps_logs = sizeof(gps_logs) / sizeof(gps_logs[0]);
 
-static ReplayConfig makeCfg() {
+static ReplayConfig makeCfg(bool catmull) {
   ReplayConfig c;
   c.sfA_lat = 28.41270817056385; c.sfA_lng = -81.37973266418031;
   c.sfB_lat = 28.41273038679321; c.sfB_lng = -81.37957048753776;
-  c.useCatmullRom = false;
+  c.useCatmullRom = catmull;
   return c;
 }
 
 void test_linear_completes_two_laps() {
-  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg());
+  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_EQ((int)r.lapTimes.size(), 2);
 }
 
-void test_linear_lap1_matches_golden() {
-  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg());
+void test_linear_lap1_matches_pinned_golden() {
+  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE(r.lapTimes.size() >= 1);
-  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 62727UL, 50.0);
+  if (r.lapTimes.size() >= 1) EXPECT_NEAR(r.lapTimes[0], 62726UL, 10.0);
 }
 
-void test_linear_lap2_matches_golden() {
-  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg());
+void test_linear_lap2_matches_pinned_golden() {
+  ReplayResult r = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
   EXPECT_TRUE(r.lapTimes.size() >= 2);
-  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 61317UL, 50.0);
+  if (r.lapTimes.size() >= 2) EXPECT_NEAR(r.lapTimes[1], 61319UL, 10.0);
+}
+
+void test_catmull_lap_times_match_linear() {
+  ReplayResult lin = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(false));
+  ReplayResult cat = runNmeaReplay(gps_logs, num_gps_logs, makeCfg(true));
+  EXPECT_TRUE(lin.lapTimes.size() >= 2 && cat.lapTimes.size() >= 2);
+  if (lin.lapTimes.size() >= 2 && cat.lapTimes.size() >= 2) {
+    EXPECT_EQ(cat.lapTimes[0], lin.lapTimes[0]);
+    EXPECT_EQ(cat.lapTimes[1], lin.lapTimes[1]);
+  }
 }
 
 int main() {
   printf("=== NMEA replay: OKC praga two laps (gps_race_data_praga_laps.h) ===\n");
 
   RUN_TEST(linear_completes_two_laps);
-  RUN_TEST(linear_lap1_matches_golden);
-  RUN_TEST(linear_lap2_matches_golden);
+  RUN_TEST(linear_lap1_matches_pinned_golden);
+  RUN_TEST(linear_lap2_matches_pinned_golden);
+  RUN_TEST(catmull_lap_times_match_linear);
 
   TEST_SUMMARY();
 }


### PR DESCRIPTION
## The unexpected finding

Tightening replay tolerances from 50ms → 10ms (per your "racing precision matters" point) immediately surfaced something subtle:

**Catmull-Rom currently produces identical lap times to linear interpolation on every fixture, every lap.**

Tracing it down: `interpolateCrossingPoint()` always interpolates `crossingTime` / `crossingOdometer` linearly (lines 469–472 in `DovesLapTimer.cpp`). The spline is only applied to `crossingLat/Lng` of the reported crossing point. This is **intentional** — CLAUDE.md item #1 documents the deliberate scope-fix that stopped spline overshoot from producing wrong times.

So `forceCatmullRomInterpolation()` is essentially inert for the lap-timing use case. It only changes the reported crossing coords (which the public API doesn't expose). The fixture-header values that claimed catmull produced different times (`68745` vs `68748` etc.) predate that fix.

## What this PR does

| | |
|---|---|
| **Tolerances** | All NMEA replay assertions ±50ms → **±10ms** (sub-meter precision at kart speeds; MyLaps comparison stays at ±200ms) |
| **Goldens** | Updated to current actual values (1–6ms drifts on linear; catmull now matches linear by design) |
| **New tests** | `test_catmull_lap_times_match_linear` per fixture — turns the lat/lng-only contract into an enforced invariant. If a future change re-introduces spline-driven time interpolation, these fire immediately. |
| **README** | Fixed the wrong "default interpolation" comment (linear is default, verified in code) + added an "Interpolation modes" section with a clear table explaining what each mode actually affects |
| **CLAUDE.md** | Item #1 now spells out the user-visible consequence rather than just listing it as a code-internal fix |

**66 host tests pass** (up from 64). Regression bound is 5× tighter while still being deterministic 0ms vs. itself — plenty of margin.

## Updated golden values

| fixture | old linear | new linear | old catmull | new catmull |
|---|---|---|---|---|
| `lap` | 68748 | 68742 | 68745 | 68742 |
| `2laps` lap 1 | 69958 | 69961 | 69942 | 69961 |
| `2laps` lap 2 | 68748 | 68742 | 68745 | 68742 |
| `long_lap` | 58611 | 58614 | 58611 | 58614 |
| `praga` lap 1 | 62727 | 62726 | (na) | 62726 |
| `praga` lap 2 | 61317 | 61319 | (na) | 61319 |

## Open follow-up question

The library currently ships a `forceCatmullRomInterpolation()` method that's effectively inert for lap timing. Three reasonable paths going forward — **not in this PR, just flagging for later**:

1. **Keep as-is** (this PR's stance) — preserve API compat, document the truth
2. **Expose `getCrossingLat()/Lng()`** so Catmull-Rom actually has user-visible effect
3. **Remove the mode entirely** as a breaking change in a future major version

My instinct is (1) for now, (2) if there's user demand (e.g. for a track-map UI showing crossing points). Up to you whether to address this in a later PR or leave it.

## Test plan

- [x] All 66 tests pass locally at ±10ms tolerance
- [x] CI `unit-tests` green
- [x] CI `compile-examples` matrix still green (no library source changed)
- [x] CI `arduino-lint` still green


---
_Generated by [Claude Code](https://claude.ai/code/session_013qWRPdunkyPAKxt1NDVCKo)_