### PR TITLE
docs: add project governance (CONTRIBUTING, SECURITY, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something isn't timing/detecting correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! The more concrete detail you give, the faster
+        it gets fixed. If it's a timing/detection issue, a sample of your GPS
+        data (NMEA log) is gold — see the `examples/real_track_data_debug/`
+        fixtures for the format we use to reproduce.
+
+  - type: input
+    id: version
+    attributes:
+      label: Library version
+      description: From the Arduino Library Manager, or the `version=` in library.properties.
+      placeholder: "4.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mcu
+    attributes:
+      label: MCU
+      options:
+        - XIAO nRF52840
+        - Arduino Mega
+        - Arduino Uno
+        - ESP32
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: gps
+    attributes:
+      label: GPS module + rate
+      placeholder: "Matek SAM-M10Q @ 25Hz"
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the library do? What did you expect instead?
+      placeholder: |
+        Expected: lap detected when crossing the start/finish line.
+        Actual: lap counter never increments / fires twice / wrong time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: sketch
+    attributes:
+      label: Minimal sketch / setup
+      description: How are you configuring the timer (lines, threshold, interpolation mode)?
+      render: cpp
+    validations:
+      required: false
+
+  - type: textarea
+    id: gps-data
+    attributes:
+      label: GPS data sample (if a timing/detection issue)
+      description: A short NMEA log or a list of (lat, lng, alt, speed, time) fixes around where it went wrong.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / usage help
+    url: https://github.com/TheAngryRaven/DovesLapTimer/discussions
+    about: For "how do I..." questions, open a Discussion rather than an issue.
+  - name: API documentation
+    url: https://theangryraven.github.io/DovesLapTimer/
+    about: Generated reference for the full public API.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep in mind DovesLapTimer deliberately does **not** talk to GPS
+        hardware — it takes coordinates + time and returns lap timing. Feature
+        requests for GPS/serial/display handling usually belong in an example
+        sketch rather than the core library.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case behind the request, not just the proposed solution.
+      placeholder: "I want to know my elevation gain per lap for hill-climb events..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API or behavior look like?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways you've thought about solving this, or workarounds you're using now.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing! Keep PRs focused on one logical change.
+See CONTRIBUTING.md for the full workflow and testing philosophy.
+-->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no behavior change)
+- [ ] Docs / examples
+- [ ] CI / tooling
+
+## Testing
+
+<!-- How did you verify this? -->
+
+- [ ] `cd test && make run` passes locally
+- [ ] Added/updated tests in the appropriate layer (unit / NMEA replay), or N/A
+- [ ] If timing output changed intentionally, updated the pinned goldens **and** explained why below
+
+## Checklist
+
+- [ ] Doc comments updated for any public API changes (feeds the API docs site)
+- [ ] `README.md` updated if user-facing behavior changed, or N/A
+- [ ] `CHANGELOG.md` updated under "Unreleased", or N/A
+- [ ] No new heap allocation in the GPS hot path; SRAM-conscious for AVR targets
+
+## Notes for reviewers
+
+<!-- Anything to call out: tradeoffs, follow-ups, areas you're unsure about. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Project governance docs: `CONTRIBUTING.md` (dev setup, the 3-layer testing
+  philosophy, PR workflow, release process), `SECURITY.md`, GitHub issue
+  forms (bug report + feature request) and a pull-request template.
+
 ## [4.1.0] – 2026-05-21
 
 A quality-and-confidence release. No breaking API changes; everything from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to DovesLapTimer
+
+Thanks for your interest in improving DovesLapTimer! This is a GPS lap-timing
+library for go-karts and race cars, and contributions — bug reports, fixes,
+new features, docs — are all welcome.
+
+## Ground rules
+
+- Be respectful. See the [Code of Conduct](CODE_OF_CONDUCT.md).
+- This library does **not** talk to GPS hardware directly. It takes
+  `(lat, lng, altitude_m, speed_knots, time_ms_since_midnight)` and returns
+  lap timing. Keep that boundary — hardware/serial parsing belongs in the
+  examples, not the core.
+- The library targets memory-constrained MCUs (down to AVR Mega). Watch your
+  SRAM and avoid heap allocation in the hot path.
+
+## Development setup
+
+You don't need any Arduino hardware to develop or test the core library.
+
+```sh
+git clone https://github.com/TheAngryRaven/DovesLapTimer.git
+cd DovesLapTimer/test
+make run          # builds + runs the full host-native test suite with g++
+```
+
+That's it — the test harness stubs the small Arduino surface the library uses
+(`Stream`, `F()`, `sq()`) so everything compiles and runs on a plain Linux/macOS
+host. See [`test/README.md`](test/README.md) for the layout.
+
+To compile the example sketches you'll need the Arduino IDE/CLI with the
+relevant board packages — but CI does this for you on every PR, so it's
+optional locally.
+
+## The testing philosophy (please read before adding code)
+
+DovesLapTimer is tested in three layers. **New behavior should land with a
+test in the appropriate layer.** This is what lets us refactor the timing core
+confidently — a regression of even a few milliseconds turns CI red.
+
+1. **Layer 1 — structural** (`arduino-lint`, `compile-examples`): lint pass +
+   every example compiles across Arduino Mega, Uno, ESP32, and XIAO nRF52840.
+   Catches missing includes, broken signatures, SRAM/flash overruns.
+2. **Layer 2 — module unit tests** (`test/test_*.cpp`): host-native tests for
+   `GeoMath`, `DirectionDetector`, the `CourseDetector` state machine, and a
+   synthetic-track integration pass over the full pipeline. Catches algorithm
+   regressions that compile fine but produce wrong numbers.
+3. **Layer 3 — NMEA replay regression** (`test/test_nmea_*.cpp`): replays real
+   Orlando Kart Center GPS recordings and asserts lap times match pinned
+   goldens within ±10 ms. Catches interpolation regressions on real-world
+   noisy data.
+
+**Adding a test:** write `test/test_<thing>.cpp` with `void test_<name>()`
+functions, list them in `main()` via `RUN_TEST(<name>)`, and `make run` picks
+it up automatically (the Makefile globs `test_*.cpp`). Use the
+`EXPECT_TRUE` / `EXPECT_EQ` / `EXPECT_NEAR` macros from `test_runner.h`.
+
+If you intentionally change timing output and a layer-3 golden shifts, update
+the pinned value in the test **and** the fixture header comment, and explain
+why in your PR.
+
+## Pull request workflow
+
+1. Fork and branch off `master`. Name branches descriptively
+   (e.g. `fix-sector-overflow`, `add-elevation-getter`).
+2. Make your change with a matching test.
+3. Run `cd test && make run` locally — all green.
+4. Update docs if you touched the public API:
+   - Doc comments (`@brief` / `@param` / `@return`) — these feed the
+     [API docs site](https://theangryraven.github.io/DovesLapTimer/).
+   - `README.md` if user-facing behavior changed.
+   - `CHANGELOG.md` under an "Unreleased" heading (Keep a Changelog format).
+5. Open a PR. CI runs all four workflows (lint, compile, unit tests, docs).
+   Fill out the PR template.
+
+Keep PRs focused — one logical change per PR is much easier to review than a
+grab-bag.
+
+## Commit messages
+
+Write a clear subject line in the imperative ("fix sector overflow", "add
+elevation getter"), and use the body to explain the *why*, not just the *what*.
+
+## Releasing (maintainers)
+
+1. Bump `version=` in `library.properties`.
+2. Move the `CHANGELOG.md` "Unreleased" entries under a new version heading.
+3. Tag the commit (`vX.Y.Z`) and push the tag — or create a GitHub Release,
+   which creates the tag.
+4. The Arduino Library Manager indexer auto-ingests the new tag within a couple
+   hours. No registry re-submission needed.
+
+## Questions
+
+Open an issue with the **question** label, or start a discussion. For anything
+sensitive, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+DovesLapTimer is an embedded lap-timing library — it parses no untrusted
+network input and runs on a hobbyist's microcontroller, so the attack surface
+is small. Still, if you find a security-relevant issue (e.g. a buffer overflow
+reachable from crafted GPS input, or a problem in an example sketch that could
+affect a connected device), we'd like to know.
+
+## Supported versions
+
+Only the latest released minor version receives fixes. Given the library's
+scope, older versions are not back-patched — update to the current release.
+
+| Version | Supported |
+| ------- | --------- |
+| 4.1.x   | ✅        |
+| < 4.1   | ❌        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for a security problem.
+
+Use GitHub's private vulnerability reporting:
+**Security → Report a vulnerability** on the repository, or contact the
+maintainer directly. Include:
+
+- The version (or commit) affected
+- A description of the issue and its impact
+- Steps to reproduce, ideally with a minimal sketch or GPS data sample
+
+We'll acknowledge within a reasonable time and work with you on a fix and
+coordinated disclosure. Since this is a volunteer-maintained hobby project,
+please be patient with response times.


### PR DESCRIPTION
## Summary

The final roadmap item (#9) — community/contribution infrastructure.

| File | What |
|---|---|
| `CONTRIBUTING.md` | Dev setup (`cd test && make run`, no hardware needed), the 3-layer testing philosophy with "new behavior lands with a test" guidance, PR workflow, commit conventions, maintainer release process |
| `SECURITY.md` | Supported versions + private vulnerability reporting, honestly scoped to a small-attack-surface embedded library |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | YAML issue form — asks for MCU, GPS module + rate, version, and a GPS data sample (most bugs are timing/detection) |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Nudges hardware/serial requests toward examples vs. the core |
| `.github/ISSUE_TEMPLATE/config.yml` | Routes usage Qs to Discussions, links the API docs site |
| `.github/pull_request_template.md` | Checklist: local test run, test-in-right-layer, golden updates, doc comments, CHANGELOG, AVR SRAM-consciousness |
| `CHANGELOG.md` | New "Unreleased" section modeling the workflow CONTRIBUTING describes |

## One thing left: CODE_OF_CONDUCT.md

repo → **Add file → Create new file** → name it `CODE_OF_CONDUCT.md` → GitHub shows a **"Choose a code of conduct template"** button → pick **Contributor Covenant** → set the contact email → commit. `CONTRIBUTING.md` already links to it, so the link resolves once it's in.

## Test plan

- [x] No source code touched — all 66 tests unaffected
- [x] CI green (lint/compile/unit/docs)
- [ ] Issue forms render correctly in the GitHub "New issue" UI
- [ ] PR template populates this PR description (you're reading the result)

## 🏁 Roadmap complete

This is the last of the 9 items. After this merges (+ you adding the CoC), the path-to-8 work is done: 3 test layers, refactored core, honest Catmull-Rom docs, Quickstart README, Doxygen site, tagged v4.1.0 release, and full governance.


---
_Generated by [Claude Code](https://claude.ai/code/session_013qWRPdunkyPAKxt1NDVCKo)_