### PR TITLE
ci: add code coverage gate + badge (gcovr)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+# Needed to push the generated badge JSON to the `badges` branch.
+permissions:
+  contents: write
+
+jobs:
+  coverage:
+    name: Line coverage (gcovr)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install g++ + gcovr
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++
+          pip install "gcovr>=7,<9"
+
+      - name: Run coverage with gate
+        # Fails the job if line coverage drops below COVERAGE_GATE (see
+        # test/Makefile). Gate starts at 1% — bump it as coverage grows.
+        working-directory: test
+        run: make coverage
+
+      - name: Generate badge JSON
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        working-directory: test
+        run: make coverage-badge
+
+      - name: Stage badge for publish
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p badge-publish
+          cp test/coverage-badge.json badge-publish/
+
+      - name: Publish badge to the `badges` branch
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: badges
+          publish_dir: ./badge-publish
+          force_orphan: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Needed to push the generated badge JSON to the `badges` branch.
+# contents: write  -> push the badge JSON to the `badges` branch (master only)
+# pull-requests: write -> post the per-PR coverage summary comment
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   coverage:
@@ -29,6 +31,43 @@ jobs:
         working-directory: test
         run: make coverage
 
+      # ---- Per-PR coverage summary comment ----
+      - name: Generate coverage summary
+        if: github.event_name == 'pull_request'
+        working-directory: test
+        run: make coverage-summary
+
+      - name: Post coverage summary comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- coverage-summary -->';
+            let report;
+            try {
+              report = fs.readFileSync('test/coverage-summary.md', 'utf8');
+            } catch (e) {
+              core.warning('No coverage-summary.md found; skipping comment.');
+              return;
+            }
+            const body = `${marker}\n${report}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            try {
+              const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+              const existing = comments.data.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
+            } catch (e) {
+              // Fork PRs get a read-only token and can't comment — warn, don't fail.
+              core.warning(`Could not post coverage comment: ${e.message}`);
+            }
+
+      # ---- Badge publish (master only) ----
       - name: Generate badge JSON
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         working-directory: test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage/
 *.gcda
 *.gcov
 test/coverage-badge.json
+test/coverage-summary.md

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ build/
 
 # Doxygen generated output (deployed to gh-pages branch by CI)
 docs-build/
+
+# Coverage artifacts (gcov instrumentation + generated badge)
+coverage/
+*.gcno
+*.gcda
+*.gcov
+test/coverage-badge.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,19 @@ GitHub Actions workflows live in `.github/workflows/`:
   https://theangryraven.github.io/DovesLapTimer/ (GitHub repo Settings →
   Pages must be set to source = gh-pages branch, folder = /).
 
-All four workflows trigger on push to `main`/`master`, on any PR, and
+- **coverage.yml** — builds the `test/` suite with `g++ --coverage`, runs it,
+  and summarizes line coverage of `src/` with `gcovr`. Gated on every PR via
+  `make coverage` (fails under `COVERAGE_GATE`, default **1%** — intentionally
+  low so it's easy to raise as coverage grows; bump the `COVERAGE_GATE ?= 1`
+  line in `test/Makefile`). On push to master it generates a shields.io
+  endpoint JSON (`make coverage-badge`) and publishes it to the `badges`
+  branch (orphan, badge JSON only) via `peaceiris/actions-gh-pages@v3`. The
+  README badge reads that JSON through `img.shields.io/endpoint`. Current line
+  coverage ~51% — `GeoMath` 100%, `CourseDetector` 93%, `DovesLapTimer` 75%,
+  but `CourseManager` and `WaypointLapTimer` sit at 0% (no direct tests yet —
+  see the path-to-8.5 notes).
+
+All five workflows trigger on push to `main`/`master`, on any PR, and
 manually via `workflow_dispatch`. Status badges are linked at the top of
 README.md.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,10 +387,13 @@ GitHub Actions workflows live in `.github/workflows/`:
   line in `test/Makefile`). On push to master it generates a shields.io
   endpoint JSON (`make coverage-badge`) and publishes it to the `badges`
   branch (orphan, badge JSON only) via `peaceiris/actions-gh-pages@v3`. The
-  README badge reads that JSON through `img.shields.io/endpoint`. Current line
-  coverage ~51% — `GeoMath` 100%, `CourseDetector` 93%, `DovesLapTimer` 75%,
-  but `CourseManager` and `WaypointLapTimer` sit at 0% (no direct tests yet —
-  see the path-to-8.5 notes).
+  README badge reads that JSON through `img.shields.io/endpoint`. On every PR
+  it also posts/updates a per-PR coverage summary comment (gcovr `--markdown`
+  via first-party `actions/github-script` — no third-party service, runs
+  entirely in-runner). Current line coverage ~51% — `GeoMath` 100%,
+  `CourseDetector` 93%, `DovesLapTimer` 75%, but `CourseManager` and
+  `WaypointLapTimer` sit at 0% (no direct tests yet — see the path-to-8.5
+  notes).
 
 All five workflows trigger on push to `main`/`master`, on any PR, and
 manually via `workflow_dispatch`. Status badges are linked at the top of

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![compile-examples](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/compile-examples.yml)
 [![arduino-lint](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/arduino-lint.yml)
 [![unit-tests](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/unit-tests.yml)
+[![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TheAngryRaven/DovesLapTimer/badges/coverage-badge.json)](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/coverage.yml)
 [![docs](https://github.com/TheAngryRaven/DovesLapTimer/actions/workflows/docs.yml/badge.svg)](https://theangryraven.github.io/DovesLapTimer/)
 
 Library for Arduino for creating damned accurate lap-timings using GPS data, on par with other commercial solutions.

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ run: all
 	fi
 
 clean:
-	rm -rf build/ coverage/ *.gcno *.gcda *.gcov coverage-badge.json
+	rm -rf build/ coverage/ *.gcno *.gcda *.gcov coverage-badge.json coverage-summary.md
 
 # ----- Coverage -----
 # Instruments the library sources, runs every test binary (gcda accumulates
@@ -90,4 +90,11 @@ c='brightgreen' if p>=90 else 'green' if p>=75 else 'yellowgreen' if p>=60 else 
 json.dump({'schemaVersion':1,'label':'coverage','message':f'{p}%','color':c}, open('coverage-badge.json','w'))"
 	@echo "wrote coverage-badge.json:" && cat coverage-badge.json && echo ""
 
-.PHONY: all run clean coverage coverage-badge
+# Emit a Markdown coverage report (overall + per-file) for posting as a
+# per-PR comment. Writes coverage-summary.md in the test dir.
+coverage-summary: $(COV_BINS)
+	@for bin in $(COV_BINS); do $$bin > /dev/null || exit 1; done
+	@gcovr --root .. --filter '\.\./src/' --markdown coverage-summary.md >/dev/null
+	@echo "wrote coverage-summary.md"
+
+.PHONY: all run clean coverage coverage-badge coverage-summary

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,6 +53,41 @@ run: all
 	fi
 
 clean:
-	rm -rf build/
+	rm -rf build/ coverage/ *.gcno *.gcda *.gcov coverage-badge.json
 
-.PHONY: all run clean
+# ----- Coverage -----
+# Instruments the library sources, runs every test binary (gcda accumulates
+# across them), and summarizes line coverage of ../src/ with gcovr. Fails if
+# below COVERAGE_GATE percent. The gate starts intentionally low — raise it
+# as coverage grows. Override on the command line: `make coverage COVERAGE_GATE=40`.
+COVERAGE_GATE ?= 1
+COV_DIR        = coverage
+COV_BINS       = $(TEST_SRCS:%.cpp=$(COV_DIR)/%)
+
+$(COV_DIR)/%: %.cpp $(LIB_SRCS) test_runner.h mock/Arduino.h mock/ArxTypeTraits.h
+	@mkdir -p $(COV_DIR)
+	$(CXX) $(CXXFLAGS) --coverage -o $@ $< $(LIB_SRCS) $(LDFLAGS)
+
+coverage: $(COV_BINS)
+	@for bin in $(COV_BINS); do \
+		echo "Running $$bin"; \
+		$$bin > /dev/null || exit 1; \
+	done
+	@echo ""
+	gcovr --root .. --filter '\.\./src/' \
+	      --fail-under-line $(COVERAGE_GATE) \
+	      --print-summary
+
+# Emit a shields.io endpoint JSON describing line coverage. Used by CI to
+# publish the README badge. Writes coverage-badge.json in the test dir.
+coverage-badge: $(COV_BINS)
+	@for bin in $(COV_BINS); do $$bin > /dev/null || exit 1; done
+	@gcovr --root .. --filter '\.\./src/' --json-summary-pretty -o /tmp/cov.json >/dev/null
+	@python3 -c "import json; \
+d=json.load(open('/tmp/cov.json')); \
+p=round(d['line_percent']); \
+c='brightgreen' if p>=90 else 'green' if p>=75 else 'yellowgreen' if p>=60 else 'yellow' if p>=40 else 'orange' if p>=20 else 'red'; \
+json.dump({'schemaVersion':1,'label':'coverage','message':f'{p}%','color':c}, open('coverage-badge.json','w'))"
+	@echo "wrote coverage-badge.json:" && cat coverage-badge.json && echo ""
+
+.PHONY: all run clean coverage coverage-badge

--- a/test/README.md
+++ b/test/README.md
@@ -49,8 +49,13 @@ tests against captured real-world noise.
 ```sh
 cd test
 make run        # build + run all suites; exits non-zero on any failure
-make clean      # remove build/
+make coverage   # build instrumented, run, print gcovr line-coverage summary
+make clean      # remove build/ + coverage artifacts
 ```
+
+`make coverage` enforces a gate (`COVERAGE_GATE`, default 1%) and fails if line
+coverage of `src/` drops below it. Raise the bar as coverage grows:
+`make coverage COVERAGE_GATE=40`, or edit the default in the Makefile.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Adds line-coverage measurement to the host test suite, a CI gate, and a live README badge — fully self-contained, no Codecov/external account or token.

| Piece | What |
|---|---|
| `test/Makefile` | `make coverage` (instrumented build + gcovr summary, gated) and `make coverage-badge` (shields endpoint JSON) |
| `.github/workflows/coverage.yml` | Runs the gate on every PR; on master push, publishes badge JSON to an orphan `badges` branch via `peaceiris/actions-gh-pages` |
| `README.md` | Coverage badge via `img.shields.io/endpoint` |
| `.gitignore`, `CLAUDE.md`, `test/README.md` | Artifacts ignored; workflow + gate documented |

## The gate

`COVERAGE_GATE` defaults to **1%** as requested — passes with huge margin, trivial to raise later:

```sh
make coverage COVERAGE_GATE=40   # or edit the default in test/Makefile
```

## Current coverage (gcovr, this branch)

```
src/GeoMath.h            100%
src/CourseDetector.cpp    93%
src/DovesLapTimer.cpp     75%
src/CourseManager.cpp      0%   ← no direct tests
src/WaypointLapTimer.cpp   0%   ← no direct tests
TOTAL                     51%
```

## Notes

- **No manual setup needed.** The badge goes live automatically once this merges and the coverage workflow runs on master (which creates the `badges` branch). Until then the shields endpoint will show "inaccessible" — same pattern as the docs/Pages rollout.
- The gate also runs on PRs, so any future PR that somehow drops coverage below the threshold fails CI.

## Test plan

- [x] `make coverage` works locally (gcovr 8.6), reports 51%, gate passes
- [x] `make coverage-badge` emits valid shields endpoint JSON
- [x] `make run` unaffected; `make clean` removes all coverage artifacts
- [x] CI `coverage` job green on this PR
- [ ] After merge: `badges` branch created, badge resolves in README


---
_Generated by [Claude Code](https://claude.ai/code/session_013qWRPdunkyPAKxt1NDVCKo)_