### PR TITLE
fix: define M_PI fallback in GeoMath.h for non-glibc/strict-ANSI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`M_PI` portability** — `GeoMath.h` now provides a fallback `#define M_PI`
+  when the platform's `<math.h>` doesn't expose it. `M_PI` is a POSIX/BSD
+  extension, not standard C/C++; glibc happens to expose it by default but
+  stricter standard libraries (under `-std=c++NN` / `__STRICT_ANSI__`) hide
+  it, breaking the host test build with `'M_PI' was not declared in this scope`.
+
 ### Added
 - Project governance docs: `CONTRIBUTING.md` (dev setup, the 3-layer testing
   philosophy, PR workflow, release process), `SECURITY.md`, GitHub issue

--- a/src/GeoMath.h
+++ b/src/GeoMath.h
@@ -13,6 +13,14 @@
 
 #include <math.h>
 
+// M_PI is not part of the C/C++ standard — it's a POSIX/BSD extension that
+// glibc happens to expose by default but stricter libcs (e.g. under
+// -std=c++NN / __STRICT_ANSI__) hide. Define a fallback so the library
+// compiles everywhere.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 static const double GEOMATH_RADIUS_EARTH = 6371.0 * 1000; // meters
 
 static inline double geoHaversine(double lat1, double lon1, double lat2, double lon2) {


### PR DESCRIPTION
M_PI is a POSIX/BSD extension, not standard C/C++. glibc exposes it by
default so CI (ubuntu) stays green, but stricter standard libraries hide
it under -std=c++NN / __STRICT_ANSI__, breaking the host test build with
"'M_PI' was not declared in this scope".

https://claude.ai/code/session_014Lmy2K6mPwB2jSRP1cEjaJ