### PR TITLE
Fix code-review findings H3–H14: low-rate GPS, detection fallbacks, dead memory, doc honesty, CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions dependencies monitored. All workflow actions are
+# pinned to commit SHAs (supply-chain hardening); Dependabot proposes PRs
+# that bump those SHAs when new releases land, so pins don't rot.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Arduino Lint
-        uses: arduino/arduino-lint-action@v2
+        uses: arduino/arduino-lint-action@4de5fc895deecbda2f6b1cc05de7a8fdd5c4c51f # v2.0.0
         with:
           project-type: library
           compliance: specification
@@ -26,7 +26,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: arduino-lint-report
           path: arduino-lint-report.json

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Seeed nRF52 BSP shells out to adafruit-nrfutil during link to package
       # the .hex into a .zip, even when we're only compiling — so install it
@@ -71,7 +71,7 @@ jobs:
         run: pip install --user adafruit-nrfutil
 
       - name: Compile sketches
-        uses: arduino/compile-sketches@v1
+        uses: arduino/compile-sketches@8ac27e99289705c4abec832089575d687b859227 # v1.1.2
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload size deltas report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: size-deltas-${{ matrix.board.alias }}
           path: sketches-reports

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
     name: Line coverage (gcovr)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install g++ + gcovr
         run: |
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run coverage with gate
         # Fails the job if line coverage drops below COVERAGE_GATE (see
-        # test/Makefile). Gate starts at 1% — bump it as coverage grows.
+        # test/Makefile, currently 80%) — keep ratcheting it up with new tests.
         working-directory: test
         run: make coverage
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Post coverage summary comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -69,19 +69,19 @@ jobs:
 
       # ---- Badge publish (master only) ----
       - name: Generate badge JSON
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         working-directory: test
         run: make coverage-badge
 
       - name: Stage badge for publish
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           mkdir -p badge-publish
           cp test/coverage-badge.json badge-publish/
 
       - name: Publish badge to the `badges` branch
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: badges

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     name: Doxygen build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Doxygen + Graphviz
         run: |
@@ -32,8 +32,8 @@ jobs:
         run: doxygen Doxyfile
 
       - name: Deploy to gh-pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs-build/html

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: Host-native unit tests (g++)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Show compiler version
         run: g++ --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Low-rate GPS silently killed all lap counting** — crossing validation
+  required the straddle pair's summed distance to the line to be under
+  `crossingThresholdMeters` in absolute meters, conflating zone size with
+  sample density: at 1 Hz / 70 km/h fixes are ~19 m apart, every genuine
+  crossing failed the check, and the lap counter never moved (the failure
+  went only to debug serial). Validation now scales with the pair's own
+  spacing (`CROSSING_PAIR_SPACING_FACTOR`), the zone-exiting fix is included
+  in the buffer so a straddle pair exists at low rates at all, a geometric
+  backstop requires the interpolated point to land on the line *segment*
+  (not its infinite extension), and rejected crossings are surfaced through
+  the new `getRejectedCrossingCount()` getter.
+- **Lap-Anything fallback was unreachable from the most likely failure
+  mode** — the fallback only fired after candidate *rejections*, but a
+  wrong/missing course config never produces candidates, leaving detection
+  (and `getActiveTimer()`) hung forever while the WaypointLapTimer silently
+  timed laps unseen. `CourseDetector` now counts completed no-match passes
+  (`getNoMatchCount()`), and `CourseManager` falls back after
+  `COURSE_DETECT_MAX_NO_MATCH_PASSES` of them — plus a distance failsafe
+  (`COURSE_DETECT_FALLBACK_DISTANCE_FACTOR` × longest course, floored at
+  `COURSE_DETECT_FALLBACK_MIN_METERS`) for the case where the waypoint is
+  never revisited at all.
+- **Lap-Anything mode left all 8 course timers running forever** —
+  `_activateLapAnything()` now deactivates every course entry, so the
+  full crossing pipelines stop being fed on every fix once the fallback is
+  active (previously `pruneInactiveCourses()` couldn't help: it
+  early-returns precisely in that no-active-course state).
+- **README "Direction Detection" described the algorithm removed in
+  2026-05-20** ("first sector line crossed determines direction"); rewritten
+  to match the actual both-sectors temporal-order resolution. Two unit lies
+  fixed with it: `getPaceDifference()` returns **ms per meter** (README said
+  "seconds", the header said "milliseconds"), and `pointLineSegmentDistance()`
+  returns **meters** (header claimed degrees). A doc-claim spot check was
+  added to the release checklist in `CONTRIBUTING.md`.
+- **Test Makefile tracked no header dependencies** — `make run` gave false
+  greens on binaries stale against `../src/*.h`, `replay_runner.h`, or the
+  NMEA fixtures (`touch ../src/DovesLapTimer.h && make` → "Nothing to be
+  done"). All headers are now prerequisites of every test binary.
+- **`M_PI`/unit-conversion literal drift** — speed/distance conversions used
+  three different hand-typed literals across five files (`1.852`,
+  `0.621371`, `1.60934` — the latter two disagree at the 7th digit). All
+  conversions now use shared `constexpr` constants in `GeoMath.h`
+  (`GEOMATH_KNOTS_TO_KMH`, `GEOMATH_KMH_TO_MPH`, `GEOMATH_MPH_TO_KMH`,
+  `GEOMATH_METERS_TO_FEET`), derived from the exact definitions of the
+  nautical and statute mile.
 - **UTC midnight rollover corrupted every time computation** — the GPS time
   base (ms since midnight) wraps 86,399,999 → 0 at UTC midnight, and every
   duration was a naked unsigned subtraction. A lap (or sector, or current-lap
@@ -44,7 +88,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stricter standard libraries (under `-std=c++NN` / `__STRICT_ANSI__`) hide
   it, breaking the host test build with `'M_PI' was not declared in this scope`.
 
+### Changed
+- **AVR (Mega/Uno) support is now documented as degraded** — on classic AVR
+  `double` is a 32-bit float, which quantizes GPS coordinates to ~0.2–0.75 m
+  and degrades odometer/interpolation accuracy; lap counting still works. A
+  compile-time `#warning` now fires on 4-byte-double targets and the README
+  hardware section spells out the limitation.
+- **Memory documentation corrected** — `pruneInactiveCourses()` saves CPU,
+  not RAM: the 8-slot course-timer array (~29 KB with 64-bit doubles) is
+  statically allocated regardless of course count and never released. The
+  README and CLAUDE.md no longer claim it "drops to ~5 KB", and now state
+  plainly that `CourseManager` does not fit on AVR Mega.
+- **Coverage gate raised from 1% to 80%** (measured line coverage is 84.5%
+  after the new suites) so deleting behavioral tests actually fails CI.
+- **CI supply-chain hardening** — every workflow action is pinned to a
+  verified commit SHA (and `peaceiris/actions-gh-pages` bumped v3 → v4),
+  `.github/dependabot.yml` keeps the pins monitored weekly, and the
+  gh-pages/badge deploy steps now require `github.ref == refs/heads/master`
+  so a `workflow_dispatch` from a feature branch can no longer overwrite
+  production docs or the coverage badge.
+
 ### Added
+- **`test_course_manager.cpp` and `test_waypoint_lap_timer.cpp`** — the two
+  largest v4.0 modules previously had zero direct tests. Now covered:
+  detection accept via `raceStarted` validation, reject → fallback (issue
+  #13 exercised through `CourseManager` where it manifested), no-match →
+  fallback, distance failsafe, Lap-Anything timer deactivation, prune
+  behavior, waypoint lap accounting, and reset semantics. Plus
+  `test_low_rate_gps.cpp` for 1 Hz / 5 Hz crossing detection and the
+  rejected-crossing counter. Line coverage: ~51% → 84.5%.
+- **`getRejectedCrossingCount()`** on `DovesLapTimer`,
+  **`getNoMatchCount()`** on `CourseDetector`, and
+  **`isCourseTimerActive(index)`** on `CourseManager`.
 
 - **GPS input validation** — `DovesLapTimer::loop()`, `WaypointLapTimer::loop()`
   and `CourseDetector::update()` now reject NaN/Inf, out-of-range, and exact
@@ -65,6 +140,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forms (bug report + feature request) and a pull-request template.
 - **`getCurrentSpeedKmh()` and `getCurrentSpeedMph()`** getters to
   `DovesLapTimer.h`, `DovesLapTimer.cpp`, `WaypointLapTimer.h` and `WaypointLapTimer.cpp`
+
+### Removed
+- **`WaypointLapTimer`'s 50-entry proximity buffer** (and the
+  `ProximityBufferEntry` struct + `WAYPOINT_LAP_BUFFER_SIZE` constant) —
+  1.6 KB of SRAM per instance that was written on every in-proximity fix
+  and never read; the closest-approach lap split only ever used three
+  scalars. `WaypointLapTimer` shrinks from ~1.8 KB to ~150 B.
 
 ## [4.1.0] – 2026-05-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,8 +178,10 @@ catches it inside a crossing zone; lap-level deltas do not.
   frames and jumping straight to Lap Anything
 
 ### WaypointLapTimer ("Lap Anything") (v4.0)
-- Fallback when no course is detected (after 3 rejections)
-- Drops waypoint at speed, uses proximity buffer (30m zone) for closest-approach timing
+- Fallback when no course is detected (after rejections / no-match passes / distance failsafe)
+- Drops waypoint at speed, tracks closest approach inside a 30m proximity zone
+  for the lap split (three scalars — the old 50-entry buffer was write-only
+  dead memory and was removed; ~150 B per instance now)
 - Duck-typed to match DovesLapTimer's public API
 - No sector support (getters return 0)
 
@@ -187,8 +189,18 @@ catches it inside a crossing zone; lap-level deltas do not.
 - Orchestrates multiple DovesLapTimers + CourseDetector + WaypointLapTimer
 - Feeds ALL active timers the same GPS data simultaneously
 - Validates detection candidates via `raceStarted` check
-- Falls back to Lap Anything after `COURSE_DETECT_MAX_REJECTIONS` (3) failures
-- `pruneInactiveCourses()` deactivates non-detected timers to save memory
+- Falls back to Lap Anything via three routes: `COURSE_DETECT_MAX_REJECTIONS`
+  (3) candidate rejections, `COURSE_DETECT_MAX_NO_MATCH_PASSES` (3) completed
+  proximity passes that matched no course length (the detector never produces
+  candidates with a wrong/missing config — pre-fix this hung detection
+  forever), or the odometer exceeding
+  `COURSE_DETECT_FALLBACK_DISTANCE_FACTOR` (4) × longest course (floored at
+  `COURSE_DETECT_FALLBACK_MIN_METERS`, 2000m) for drivers who never return
+  to the waypoint
+- Activating Lap Anything deactivates ALL course timers (they'd never be
+  surfaced again; pre-fix they kept burning CPU on every fix forever)
+- `pruneInactiveCourses()` stops *processing* non-detected timers — saves
+  CPU per fix, frees ZERO bytes (the 8-slot array is statically allocated)
 
 ### Memory Management
 - Circular buffer `crossingPointBuffer` sized per platform:
@@ -201,7 +213,13 @@ catches it inside a crossing zone; lap-level deltas do not.
   so the seam pair (newest adjacent to oldest) can't masquerade as a crossing
 - Buffer is shared between all line crossings (start/finish + sectors)
 - Mutual exclusion: only one line can be "crossing" at a time
-- CourseManager peak: ~24 KB during detection (8 courses), drops to ~5 KB after pruning
+- CourseManager: ~29 KB with 64-bit doubles (8 × ~3.6 KB by-value timer array,
+  allocated for MAX_COURSES regardless of configured course count). Pruning /
+  Lap-Anything deactivation save CPU only — no memory is ever released. Does
+  NOT fit on AVR Mega (8 KB SRAM)
+- Classic AVR additionally runs with 32-bit `double` — a `#warning` fires at
+  compile time; lap counting works but odometer/interpolation accuracy is
+  degraded (see README hardware notes)
 
 ### Shared GeoMath (v4.0)
 - `GeoMath.h` provides `geoHaversine()` and `geoHaversine3D()` as `static inline` functions
@@ -252,6 +270,7 @@ catches it inside a crossing zone; lap-level deltas do not.
 | `getPaceDifference()` | Pace delta vs best lap |
 | `getDirection()` | DIR_UNKNOWN/DIR_FORWARD/DIR_REVERSE |
 | `isDirectionResolved()` | True once direction is known |
+| `getRejectedCrossingCount()` | Zone exits whose interpolation was rejected |
 
 ### WaypointLapTimer API (duck-typed to DovesLapTimer)
 Same timing/state getters as DovesLapTimer. Sector getters return 0. Additional:
@@ -271,6 +290,7 @@ Same timing/state getters as DovesLapTimer. Sector getters return 0. Additional:
 | `getState()` | Current detection state |
 | `isDetected()` | True if course detected |
 | `getDetectedCourseIndex()` | Index of detected course |
+| `getNoMatchCount()` | Completed proximity passes that matched no course |
 
 ### CourseManager API
 | Method | Returns |
@@ -278,7 +298,8 @@ Same timing/state getters as DovesLapTimer. Sector getters return 0. Additional:
 | `updateCurrentTime(ms)` | Feed time to all timers |
 | `loop(lat, lng, alt, speedKnots)` | Feed GPS to all timers + detector |
 | `reset()` | Reset everything |
-| `pruneInactiveCourses()` | Free non-detected timer memory |
+| `pruneInactiveCourses()` | Stop feeding non-detected timers (CPU only, frees no RAM) |
+| `isCourseTimerActive(index)` | True while that course's timer is still fed |
 | `isDetectionComplete()` | True if course detected or Lap Anything active |
 | `getActiveTimer()` | Pointer to detected course's DovesLapTimer |
 | `getLapAnythingTimer()` | Pointer to WaypointLapTimer |
@@ -323,7 +344,11 @@ struct TrackConfig {
 | `COURSE_DETECT_MAX_REJECTIONS` | 3 | Rejections before Lap Anything fallback |
 | `WAYPOINT_LAP_MIN_DISTANCE_METERS` | 100.0 | Min travel for waypoint lap timer |
 | `WAYPOINT_LAP_PROXIMITY_METERS` | 30.0 | Proximity zone for waypoint timing |
-| `WAYPOINT_LAP_BUFFER_SIZE` | 50 | Proximity buffer entries |
+| `COURSE_DETECT_MAX_NO_MATCH_PASSES` | 3 | No-match laps before Lap Anything fallback |
+| `COURSE_DETECT_FALLBACK_DISTANCE_FACTOR` | 4.0 | × longest course = detection distance failsafe |
+| `COURSE_DETECT_FALLBACK_MIN_METERS` | 2000.0 | Floor for the distance failsafe |
+| `CROSSING_PAIR_SPACING_FACTOR` | 1.25 | Crossing-pair sum bound scales with fix spacing |
+| `GEOMATH_KNOTS_TO_KMH` etc. | — | Shared unit-conversion constants (`GeoMath.h`) |
 | `DIR_UNKNOWN/DIR_FORWARD/DIR_REVERSE` | 0/1/2 | Direction detection states |
 | `DETECT_STATE_*` | 0-4 | Course detection state machine states |
 | `DOVES_MILLIS_PER_DAY` | 86400000 | GPS time-of-day wrap point (UTC midnight) |
@@ -359,6 +384,12 @@ struct TrackConfig {
 16. ~~**Course detection falsely matched longer layouts on no-match laps**~~: Fixed (2026-06-11, code-review C3). `_checkWaypointProximity` now re-anchors `_waypointOdometer` after a completed proximity pass with no match, so `distanceSinceWaypoint` can't accumulate across laps and match a 2x-length layout (same root-cause class as #13).
 17. ~~**Zero GPS input validation — NaN/(0,0) fix poisoned state forever**~~: Fixed (2026-06-11, code-review H1). `DovesLapTimer::loop()`, `WaypointLapTimer::loop()`, and `CourseDetector::update()` validate input via `GeoMath.h::geoCoordinatesValid()`/`geoIsFinite()`; teleport fixes are dropped with a 3-fix re-accept (see Main Loop Flow). Tests: `test/test_input_validation.cpp`.
 18. ~~**Crossing-buffer wraparound broke the interpolator's chronology assumption**~~: Fixed (2026-06-11, code-review H2). The interpolator unwinds the ring chronologically before scanning (see Memory Management). Triggered by a kart parked on/near the line — standing start, red flag. Tests: `test/test_buffer_wraparound.cpp`.
+19. **AVR `double` is 32-bit — degraded precision** (code-review H3): documented + `#warning` on 4-byte-double targets (2026-06-11). Lap counting works; odometer/interpolation accuracy degraded. The *full* fix (local-tangent-plane offsets from a reference point so float precision suffices) was deferred — see PR notes.
+20. ~~**Low-rate GPS silently killed lap counting**~~: Fixed (2026-06-11, code-review H4). Crossing validation now scales with the straddle pair's spacing (`CROSSING_PAIR_SPACING_FACTOR`), the zone-exiting fix is buffered, an on-segment geometric check backstops the looser bound, and rejections surface via `getRejectedCrossingCount()`. Tests: `test/test_low_rate_gps.cpp`.
+21. ~~**Lap-Anything fallback unreachable when no candidates ever ranked**~~: Fixed (2026-06-11, code-review H5). No-match pass counter + odometer failsafe both feed the fallback (see CourseManager section). Tests: `test/test_course_manager.cpp`.
+22. ~~**"Pruning saves memory" was false; Lap-Anything left 8 timers running**~~: Fixed/corrected (2026-06-11, code-review H6+H7). Docs now state pruning saves CPU only (~29 KB statically allocated either way; CourseManager cannot fit on AVR Mega); `_activateLapAnything()` deactivates all course timers. The placement-new storage-pool redesign that would actually release memory was deferred — see PR notes.
+23. ~~**WaypointLapTimer carried 1.6 KB of write-only buffer**~~: Removed (2026-06-11, code-review H8). Closest-approach scalars suffice; `WAYPOINT_LAP_BUFFER_SIZE` and `ProximityBufferEntry` deleted. Instance size ~150 B.
+24. **Five-unit API surface** (code-review H14): knots into `loop()`, km/h into `CourseDetector::update()`, mph thresholds, feet course lengths, meters everywhere else. Conversions now go through shared `GeoMath.h` constants so they can't drift, but standardizing new API on one speed unit remains future work (breaking change).
 
 ## Supported Hardware
 
@@ -404,7 +435,7 @@ GitHub Actions workflows live in `.github/workflows/`:
 - **docs.yml** — builds Doxygen HTML from `src/` + `examples/` + `README.md` +
   `DETECTION.md` using the doxygen-awesome-css theme vendored under `docs/`.
   On push to master, deploys the output (`docs-build/html/`) to the
-  `gh-pages` branch via `peaceiris/actions-gh-pages@v3` with
+  `gh-pages` branch via `peaceiris/actions-gh-pages` (v4, SHA-pinned) with
   `force_orphan: true` (keeps the gh-pages branch lean — overwrites
   rather than accumulating history). On PR, builds-only without
   deploying so we catch a broken Doxyfile before merge. Live site:
@@ -413,18 +444,25 @@ GitHub Actions workflows live in `.github/workflows/`:
 
 - **coverage.yml** — builds the `test/` suite with `g++ --coverage`, runs it,
   and summarizes line coverage of `src/` with `gcovr`. Gated on every PR via
-  `make coverage` (fails under `COVERAGE_GATE`, default **1%** — intentionally
-  low so it's easy to raise as coverage grows; bump the `COVERAGE_GATE ?= 1`
-  line in `test/Makefile`). On push to master it generates a shields.io
-  endpoint JSON (`make coverage-badge`) and publishes it to the `badges`
-  branch (orphan, badge JSON only) via `peaceiris/actions-gh-pages@v3`. The
+  `make coverage` (fails under `COVERAGE_GATE`, currently **80%** — sits just
+  below measured coverage; keep ratcheting it up alongside new tests via the
+  `COVERAGE_GATE ?=` line in `test/Makefile`). On push to master it generates
+  a shields.io endpoint JSON (`make coverage-badge`) and publishes it to the
+  `badges` branch (orphan, badge JSON only) via `peaceiris/actions-gh-pages`. The
   README badge reads that JSON through `img.shields.io/endpoint`. On every PR
   it also posts/updates a per-PR coverage summary comment (gcovr `--markdown`
   via first-party `actions/github-script` — no third-party service, runs
-  entirely in-runner). Current line coverage ~51% — `GeoMath` 100%,
-  `CourseDetector` 93%, `DovesLapTimer` 75%, but `CourseManager` and
-  `WaypointLapTimer` sit at 0% (no direct tests yet — see the path-to-8.5
-  notes).
+  entirely in-runner). Current line coverage ~84.5% (gate at 80) — every
+  module now has direct tests, including `CourseManager`
+  (`test_course_manager.cpp`) and `WaypointLapTimer`
+  (`test_waypoint_lap_timer.cpp`).
+
+Supply chain: every `uses:` is pinned to a verified commit SHA (with a
+trailing `# vX` comment naming the release), `.github/dependabot.yml`
+(github-actions ecosystem, weekly, grouped) keeps the pins from rotting, and
+the gh-pages/badge deploy steps additionally require
+`github.ref == 'refs/heads/master'` so a `workflow_dispatch` from a feature
+branch cannot overwrite production docs or the badge.
 
 All five workflows trigger on push to `main`/`master`, on any PR, and
 manually via `workflow_dispatch`. Status badges are linked at the top of
@@ -437,11 +475,14 @@ README.md.
   missing includes, broken API signatures, fatal SRAM/flash overruns.
 - **Layer 2 — host unit tests** (`unit-tests.yml`): runs `test/` on the
   host via `make run`. Covers `GeoMath`, `DirectionDetector`,
-  `CourseDetector` state machine, a synthetic-track integration
+  `CourseDetector` state machine, `CourseManager` orchestration
+  (`test_course_manager.cpp`), `WaypointLapTimer`
+  (`test_waypoint_lap_timer.cpp`), a synthetic-track integration
   pass over the full `DovesLapTimer` pipeline, plus regression suites for
   midnight rollover (`test_midnight_rollover.cpp`), adversarial GPS input
-  (`test_input_validation.cpp`), and crossing-buffer wraparound
-  (`test_buffer_wraparound.cpp`). Catches algorithm
+  (`test_input_validation.cpp`), crossing-buffer wraparound
+  (`test_buffer_wraparound.cpp`), and low-rate GPS crossing detection
+  (`test_low_rate_gps.cpp`). Catches algorithm
   regressions that compile fine but produce wrong numbers. See
   `test/README.md` for layout and how to add a suite.
 - **Layer 3 — NMEA replay regression** (`unit-tests.yml`, same job): replays the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,15 @@ elevation getter"), and use the body to explain the *why*, not just the *what*.
 
 1. Bump `version=` in `library.properties`.
 2. Move the `CHANGELOG.md` "Unreleased" entries under a new version heading.
-3. Tag the commit (`vX.Y.Z`) and push the tag — or create a GitHub Release,
+3. **Doc-claim spot check**: for every behavior touched this release, read the
+   matching README section and header `@brief`/`@return` aloud against the
+   code. Docs have drifted into outright lies before (the README described a
+   direction-detection algorithm a previous release had removed; two getters
+   documented the wrong units). If the sentence describes code that no longer
+   exists, fix it before tagging.
+4. Tag the commit (`vX.Y.Z`) and push the tag — or create a GitHub Release,
    which creates the tag.
-4. The Arduino Library Manager indexer auto-ingests the new tag within a couple
+5. The Arduino Library Manager indexer auto-ingests the new tag within a couple
    hours. No registry re-submission needed.
 
 ## Questions

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To run locally: `cd test && make run`.
 - **Automatic Course Detection** - Drive a lap at any track and the library figures out which course layout you're on by matching driven distance against known courses. No manual selection needed.
 - **Multi-Course Support** - Define up to 8 course layouts per track (different configurations, rental vs. pro layouts, etc). `CourseManager` orchestrates them all.
 - **Direction Detection** - Automatically detects whether you're driving the course forward or reverse from the temporal order of sector-line crossings within a lap window. Glitch-resistant — needs both physical sector lines crossed in a lap before resolving, so a single GPS teleport can't lock the wrong direction.
-- **"Lap Anything" Fallback** - If course detection fails after 3 attempts, falls back to `WaypointLapTimer` which drops a waypoint and uses proximity-based timing. Works on any track, anywhere - no pre-configured lines needed.
+- **"Lap Anything" Fallback** - If course detection fails (3 rejected candidate sets, 3 laps matching no configured course length, or too much distance driven without detection resolving), falls back to `WaypointLapTimer` which drops a waypoint and uses proximity-based timing. Works on any track, anywhere - no pre-configured lines needed.
 - **Configurable Thresholds** - Speed, proximity, and detection thresholds are now adjustable at runtime via setter methods.
 
 ## Supported Hardware: MCU
@@ -65,7 +65,13 @@ To run locally: `cd test && make run`.
 While this is technially an arduino library, this needs a device with a large amount of ram and processing power due to all the floating point math.
 
 - Arduino Mega+
-  - Technically appears to be working, really pushing it
+  - Compiles and counts laps, but runs **degraded**: on classic AVR `double`
+    is a 32-bit float (~7 significant digits), which quantizes real-world
+    GPS coordinates to roughly 0.2–0.75 m and makes per-fix odometer
+    increments and interpolated crossing times noticeably less accurate.
+    The compiler emits a `#warning` on these targets. `CourseManager` does
+    **not** fit in a Mega's 8 KB SRAM at all — see "Memory Usage" below.
+    Full advertised precision needs a true 64-bit-double MCU.
 - [Seed NRF52840 (Recommended)](https://www.amazon.com/Seeed-Studio-XIAO-nRF52840-Microcontroller/dp/B09T9VVQG7)
   - Has a dedicated high speed FPU for both floats and doubles
   - Fast enough to support GPS/Display/SDCard Logging
@@ -262,7 +268,7 @@ Now if you want any running information, you have the following...
   unsigned long getCurrentLapTime() const; // The current lap time in milliseconds.
   unsigned long getLastLapTime() const; // The last lap time in milliseconds.
   unsigned long getBestLapTime() const; // The best lap time in milliseconds.
-  float getPaceDifference() const; // Calculates the pace difference (in seconds...) between the current lap and the best lap.
+  float getPaceDifference() const; // Pace delta vs the best lap, in milliseconds PER METER (positive = slower than best pace).
   float getCurrentLapOdometerStart() const; // The distance traveled at the start of the current lap in meters.
   float getCurrentLapDistance() const; // The distance traveled during the current lap in meters.
   float getLastLapDistance() const; // The distance traveled during the last lap in meters.
@@ -384,8 +390,8 @@ void loop() {
   const char* getTrackName() const;     // Track long name.
   const char* getShortName() const;     // Track short name.
 
-  // Memory management
-  void pruneInactiveCourses();          // Deactivate non-detected timers to save RAM.
+  // Processing management
+  void pruneInactiveCourses();          // Stop feeding non-detected timers (saves CPU per fix; frees no RAM).
 
   // Threshold setters (adjustable at runtime)
   void setSpeedThresholdMph(float mph);           // Speed to trigger detection (default 20 mph).
@@ -441,9 +447,9 @@ If no candidates match or validation fails 3 times, `CourseManager` activates "L
 
 When sector lines are configured, the library automatically detects whether you're driving the course forward or in reverse:
 
-- After the start/finish line is first crossed, the first sector line you cross determines direction
-- Sector 2 first = **forward** (`DIR_FORWARD`)
-- Sector 3 first = **reverse** (`DIR_REVERSE`)
+- After the start/finish line is first crossed, the library collects the timestamps of the physical sector 2 and sector 3 crossings during each lap
+- At the next start/finish crossing, if **both** sector lines were crossed that lap, their temporal order resolves the direction: sector 2 before sector 3 = **forward** (`DIR_FORWARD`), sector 3 before sector 2 = **reverse** (`DIR_REVERSE`)
+- Laps where only one sector line was seen (missed zone, low GPS rate) are discarded and detection retries on the next lap; within a lap, the *latest* crossing of each sector line wins, so an early GPS-glitch phantom gets overwritten by the real crossing
 - Once resolved, direction is locked and sector lines are remapped internally so timing stays correct
 
 ```c
@@ -483,9 +489,9 @@ When sector lines are configured, the library automatically detects whether you'
 
 ## Memory Usage
 
-During course detection, the library uses up to ~24 KB of RAM (8 course timers running simultaneously). After detection completes, call `pruneInactiveCourses()` to deactivate unused timers and drop to ~5 KB.
+A `CourseManager` instance is ~29 KB on a 64-bit-double MCU, dominated by a fixed by-value array of `MAX_COURSES` (8) course timers at ~3.6 KB each. That memory is **statically allocated for all 8 slots regardless of how many courses you configure**, and it is never released: `pruneInactiveCourses()` (and the automatic deactivation when "Lap Anything" activates) stop deactivated timers from being *processed* — saving CPU per GPS fix — but free zero bytes. `CourseManager` therefore does not fit on AVR-class boards (Mega: 8 KB SRAM); it needs an MCU like the XIAO nRF52840 (256 KB).
 
-If using `DovesLapTimer` standalone (no `CourseManager`), memory usage is much lower - just the single timer instance with its crossing point buffer (100 entries on boards with >3KB RAM, 25 entries otherwise).
+If using `DovesLapTimer` standalone (no `CourseManager`), memory usage is much lower — a single timer instance is ~3.6 KB, mostly its crossing point buffer (100 entries on boards with >3KB RAM, 25 entries otherwise).
 
 ## License
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,6 @@ CourseInfo	KEYWORD1
 CourseTimerEntry	KEYWORD1
 DetectionCandidate	KEYWORD1
 crossingPointBufferEntry	KEYWORD1
-ProximityBufferEntry	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -65,6 +64,7 @@ getBestSector3LapNumber	KEYWORD2
 getCurrentSector	KEYWORD2
 areSectorLinesConfigured	KEYWORD2
 isStartFinishLineConfigured	KEYWORD2
+getRejectedCrossingCount	KEYWORD2
 
 # DovesLapTimer — direction detection
 getDirection	KEYWORD2
@@ -85,6 +85,7 @@ getActiveCourseIndex	KEYWORD2
 getActiveCourseName	KEYWORD2
 getCourseCount	KEYWORD2
 getDetectionRejectionCount	KEYWORD2
+isCourseTimerActive	KEYWORD2
 getActiveTimer	KEYWORD2
 getLapAnythingTimer	KEYWORD2
 isLapAnythingActive	KEYWORD2
@@ -108,6 +109,7 @@ getWaypointLat	KEYWORD2
 getWaypointLng	KEYWORD2
 getRankedMatchCount	KEYWORD2
 getRankedMatches	KEYWORD2
+getNoMatchCount	KEYWORD2
 
 # WaypointLapTimer
 setProximityMeters	KEYWORD2
@@ -145,10 +147,17 @@ METERS_TO_FEET	LITERAL1
 # Waypoint lap timer tunables
 WAYPOINT_LAP_MIN_DISTANCE_METERS	LITERAL1
 WAYPOINT_LAP_PROXIMITY_METERS	LITERAL1
-WAYPOINT_LAP_BUFFER_SIZE	LITERAL1
 
 # GPS input validation / time base
 DOVES_MILLIS_PER_DAY	LITERAL1
 GPS_MAX_PLAUSIBLE_JUMP_METERS	LITERAL1
 GPS_JUMP_REACCEPT_COUNT	LITERAL1
 CROSSING_MAX_FIX_GAP_MS	LITERAL1
+CROSSING_PAIR_SPACING_FACTOR	LITERAL1
+COURSE_DETECT_MAX_NO_MATCH_PASSES	LITERAL1
+COURSE_DETECT_FALLBACK_DISTANCE_FACTOR	LITERAL1
+COURSE_DETECT_FALLBACK_MIN_METERS	LITERAL1
+GEOMATH_KNOTS_TO_KMH	LITERAL1
+GEOMATH_KMH_TO_MPH	LITERAL1
+GEOMATH_MPH_TO_KMH	LITERAL1
+GEOMATH_METERS_TO_FEET	LITERAL1

--- a/src/CourseDetector.cpp
+++ b/src/CourseDetector.cpp
@@ -28,6 +28,7 @@ void CourseDetector::reset() {
   _waypointOdometer = 0;
   _detectedCourseIndex = -1;
   _rankedMatchCount = 0;
+  _noMatchCount = 0;
 }
 
 void CourseDetector::update(double lat, double lng, float speedKmh, float totalOdometer) {
@@ -51,7 +52,7 @@ void CourseDetector::update(double lat, double lng, float speedKmh, float totalO
 }
 
 void CourseDetector::_checkSpeedThreshold(double lat, double lng, float speedKmh, float totalOdometer) {
-  float speedMph = speedKmh * 0.621371;
+  float speedMph = speedKmh * GEOMATH_KMH_TO_MPH;
 
   if (speedMph >= _speedThresholdMph) {
     _waypointLat = lat;
@@ -78,6 +79,7 @@ void CourseDetector::_checkWaypointProximity(double lat, double lng, float total
       // laps and a second pass would falsely match a longer layout (same
       // root cause as the rejection-cooldown bug, CLAUDE.md issue #13).
       _waypointOdometer = totalOdometer;
+      _noMatchCount++;
     }
   }
 }
@@ -173,4 +175,8 @@ int CourseDetector::getRankedMatchCount() const {
 
 const DetectionCandidate* CourseDetector::getRankedMatches() const {
   return _rankedMatches;
+}
+
+int CourseDetector::getNoMatchCount() const {
+  return _noMatchCount;
 }

--- a/src/CourseDetector.h
+++ b/src/CourseDetector.h
@@ -50,6 +50,10 @@ public:
   bool hasWaypoint() const;
   int getRankedMatchCount() const;
   const DetectionCandidate* getRankedMatches() const;
+  // Completed proximity passes (full laps back at the waypoint) that matched
+  // no configured course. CourseManager uses this to reach the Lap Anything
+  // fallback even when the detector never produces candidates to reject.
+  int getNoMatchCount() const;
 
 private:
   void _checkSpeedThreshold(double lat, double lng, float speedKmh, float totalOdometer);
@@ -65,6 +69,7 @@ private:
   int _detectedCourseIndex;
   DetectionCandidate _rankedMatches[MAX_COURSES];
   int _rankedMatchCount;
+  int _noMatchCount;
   float _speedThresholdMph;
   float _detectionProximityMeters;
 };

--- a/src/CourseManager.cpp
+++ b/src/CourseManager.cpp
@@ -65,6 +65,21 @@ void CourseManager::_initCourses(TrackConfig& config) {
     _courseTimers[i].lengthFt = 0;
   }
 
+  // Distance failsafe: detection should resolve within a few laps of the
+  // longest layout; past that, surface the Lap Anything timer instead of
+  // hanging in WAYPOINT_SET forever.
+  float longestCourseMeters = 0;
+  for (int i = 0; i < _courseCount; i++) {
+    float courseMeters = _courseTimers[i].lengthFt / METERS_TO_FEET;
+    if (courseMeters > longestCourseMeters) {
+      longestCourseMeters = courseMeters;
+    }
+  }
+  _fallbackDistanceMeters = COURSE_DETECT_FALLBACK_DISTANCE_FACTOR * longestCourseMeters;
+  if (_fallbackDistanceMeters < COURSE_DETECT_FALLBACK_MIN_METERS) {
+    _fallbackDistanceMeters = COURSE_DETECT_FALLBACK_MIN_METERS;
+  }
+
   // Create the detector with course names and lengths
   if (_courseCount > 0) {
     CourseInfo courseInfos[MAX_COURSES];
@@ -107,7 +122,7 @@ int CourseManager::loop(double lat, double lng, float altMeters, float speedKnot
 
   // Feed the detector
   if (!_detectionComplete && _courseCount > 0) {
-    float speedKmh = speedKnots * 1.852;
+    float speedKmh = speedKnots * GEOMATH_KNOTS_TO_KMH;
 
     // Get odometer from first active timer
     float odometer = 0;
@@ -123,6 +138,20 @@ int CourseManager::loop(double lat, double lng, float altMeters, float speedKnot
     // Handle candidates_ready state
     if (_detector.getState() == DETECT_STATE_CANDIDATES_READY) {
       _handleCandidatesReady(odometer);
+    }
+
+    // Fallback paths the rejection counter can't reach: the detector only
+    // produces candidates when a lap length matches within tolerance, so a
+    // wrong/missing config used to leave detection (and getActiveTimer())
+    // hung forever while the WaypointLapTimer silently timed laps unseen.
+    if (!_detectionComplete) {
+      if (_detector.getNoMatchCount() >= COURSE_DETECT_MAX_NO_MATCH_PASSES) {
+        debugln(F("No course length matched after max passes - activating Lap Anything"));
+        _activateLapAnything();
+      } else if (odometer > _fallbackDistanceMeters) {
+        debugln(F("Detection distance failsafe reached - activating Lap Anything"));
+        _activateLapAnything();
+      }
     }
   }
 
@@ -167,6 +196,13 @@ void CourseManager::_handleCandidatesReady(float currentOdometer) {
 void CourseManager::_activateLapAnything() {
   _lapAnythingActive = true;
   _detectionComplete = true;
+  // No course timer will ever be surfaced in this mode — stop feeding all
+  // of them. Without this, every fix kept running up to MAX_COURSES full
+  // crossing pipelines forever (and pruneInactiveCourses() couldn't help:
+  // it early-returns when no course is active, which is exactly this state).
+  for (int i = 0; i < _courseCount; i++) {
+    _courseTimers[i].active = false;
+  }
 }
 
 void CourseManager::pruneInactiveCourses() {
@@ -221,6 +257,11 @@ int CourseManager::getCourseCount() const {
 
 int CourseManager::getDetectionRejectionCount() const {
   return _detectionRejectionCount;
+}
+
+bool CourseManager::isCourseTimerActive(int index) const {
+  if (index < 0 || index >= _courseCount) return false;
+  return _courseTimers[index].active;
 }
 
 DovesLapTimer* CourseManager::getActiveTimer() {

--- a/src/CourseManager.h
+++ b/src/CourseManager.h
@@ -56,6 +56,10 @@ public:
   const char* getActiveCourseName() const;
   int getCourseCount() const;
   int getDetectionRejectionCount() const;
+  // True while the given course's timer is still being fed GPS data.
+  // Courses are deactivated by pruneInactiveCourses() after detection, or
+  // automatically when the Lap Anything fallback activates.
+  bool isCourseTimerActive(int index) const;
 
   // Timer access
   DovesLapTimer* getActiveTimer();
@@ -101,6 +105,10 @@ private:
   bool _detectionComplete;
   bool _lapAnythingActive;
   int _detectionRejectionCount;
+  // Odometer reading beyond which incomplete detection falls back to Lap
+  // Anything (factor x longest configured course, floored — see
+  // COURSE_DETECT_FALLBACK_* in DovesLapTimer.h).
+  float _fallbackDistanceMeters;
 
   const char* _trackLongName;
   const char* _trackShortName;

--- a/src/DovesLapTimer.cpp
+++ b/src/DovesLapTimer.cpp
@@ -73,7 +73,7 @@ int DovesLapTimer::loop(double currentLat, double currentLng, float currentAltit
   positionPrevAlt = currentAltitudeMeters;
 
   // update current speed
-  currentSpeedkmh = currentSpeedKnots * 1.852;
+  currentSpeedkmh = currentSpeedKnots * GEOMATH_KNOTS_TO_KMH;
 
   // run calculations for each crossing-line
   // Only one line can be "crossing" at a time due to shared buffer.
@@ -218,6 +218,18 @@ LineDetectResult DovesLapTimer::_detectLineCrossing(
       debugln(F(" crossed, calculating..."));
       crossingFlag = false;
 
+      // Include the exiting fix itself: at low GPS rates (1-5 Hz) the line
+      // is often crossed between the last in-zone fix and this one, and
+      // without it the buffer holds no straddling pair at all. At high
+      // rates it sits beyond the (earlier) genuine pair and is ignored.
+      crossingPointBuffer[crossingPointBufferIndex].lat = currentLat;
+      crossingPointBuffer[crossingPointBufferIndex].lng = currentLng;
+      crossingPointBuffer[crossingPointBufferIndex].time = millisecondsSinceMidnight;
+      crossingPointBuffer[crossingPointBufferIndex].odometer = totalDistanceTraveled;
+      crossingPointBuffer[crossingPointBufferIndex].speedKmh = currentSpeedkmh;
+      crossingPointBufferIndex = (crossingPointBufferIndex + 1) % crossingPointBufferSize;
+      if (crossingPointBufferIndex == 0) crossingPointBufferFull = true;
+
       outLat = 0.0; outLng = 0.0; outOdometer = 0.0; outTime = 0;
       bool validCrossing = interpolateCrossingPoint(outLat, outLng, outTime, outOdometer,
                                                     pointALat, pointALng, pointBLat, pointBLng);
@@ -227,6 +239,11 @@ LineDetectResult DovesLapTimer::_detectLineCrossing(
         debug(F("  crossingLng: "));  debugln(outLng, 6);
         debug(F("  crossingOdometer: ")); debugln(outOdometer);
         debug(F("  crossingTime: ")); debugln(outTime);
+      } else {
+        // Surface the failure — debug serial is usually not connected on
+        // track, and a silently swallowed crossing looks like a dead lap
+        // counter to the user.
+        rejectedCrossingCount++;
       }
 
       crossingPointBufferIndex = 0;
@@ -493,10 +510,32 @@ bool DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
   debug(F("crossingSumDistances: "));
   debugln(crossingSumDistances);
 
-  // Validate: the crossing pair must exist and be close enough to the line
-  if (crossingSumDistances < crossingThresholdMeters && crossingIndexA != -1 && crossingIndexB != -1) {
+  if (crossingIndexA == -1 || crossingIndexB == -1) {
+    debugln(F("~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~"));
+    return false;
+  }
+
+  {
     const crossingPointBufferEntry& entryA = entryAt(crossingIndexA);
     const crossingPointBufferEntry& entryB = entryAt(crossingIndexB);
+
+    // Validate: the crossing pair must hug the line *relative to the GPS
+    // sample spacing*, not in absolute meters. The old absolute check
+    // (sum < crossingThresholdMeters) conflated zone size with sample
+    // density: at 1 Hz / 70 km/h consecutive fixes are ~19 m apart, every
+    // genuine crossing failed the 7 m bound, and the lap counter silently
+    // never incremented. For a pair genuinely straddling the line, the sum
+    // of the two distances can never exceed the pair's own spacing, so a
+    // spacing-scaled bound stays tight at any sample rate.
+    double pairSpacing = haversine(entryA.lat, entryA.lng, entryB.lat, entryB.lng);
+    double allowedSum = CROSSING_PAIR_SPACING_FACTOR * pairSpacing;
+    if (allowedSum < crossingThresholdMeters) {
+      allowedSum = crossingThresholdMeters;
+    }
+    if (crossingSumDistances > allowedSum) {
+      debugln(F("~~~ INVALID CROSSING: pair too far from line ~~~"));
+      return false;
+    }
 
     // Time deltas are computed in double, normalized across the UTC midnight
     // wrap, and sanity-clamped BEFORE any conversion back to unsigned long —
@@ -512,12 +551,24 @@ bool DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
       return false;
     }
 
-    debugln(F("~~~ VALID CROSSING ~~~"));
-
     // Compute the interpolation factor (t) from distances and speeds at the crossing pair
     double distA = pointLineSegmentDistance(entryA.lat, entryA.lng, pointALat, pointALng, pointBLat, pointBLng);
     double distB = pointLineSegmentDistance(entryB.lat, entryB.lng, pointALat, pointALng, pointBLat, pointBLng);
     double t = interpolateWeight(distA, distB, entryA.speedKmh, entryB.speedKmh);
+
+    // Geometric sanity: the interpolated point must land on the crossing
+    // line *segment* (within the threshold), not on its infinite extension
+    // — pointOnSideOfLine treats the line as infinite, so a pair straddling
+    // the extension beyond an endpoint would otherwise slip through now
+    // that the sum bound scales with fix spacing.
+    double linearLat = entryA.lat + t * (entryB.lat - entryA.lat);
+    double linearLng = entryA.lng + t * (entryB.lng - entryA.lng);
+    if (pointLineSegmentDistance(linearLat, linearLng, pointALat, pointALng, pointBLat, pointBLng) > crossingThresholdMeters) {
+      debugln(F("~~~ INVALID CROSSING: crossing point off the line segment ~~~"));
+      return false;
+    }
+
+    debugln(F("~~~ VALID CROSSING ~~~"));
 
     // Time and odometer are always interpolated linearly (monotonic values that
     // should not overshoot), regardless of the interpolation mode for position.
@@ -530,12 +581,8 @@ bool DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
     crossingTime = (unsigned long)crossingTimeMs;
 
     if (forceLinear) {
-      // Linear interpolation for position
-      double deltaLat = entryB.lat - entryA.lat;
-      double deltaLon = entryB.lng - entryA.lng;
-
-      crossingLat = entryA.lat + t * deltaLat;
-      crossingLng = entryA.lng + t * deltaLon;
+      crossingLat = linearLat;
+      crossingLng = linearLng;
     } else {
       // Catmull-Rom spline interpolation for position only.
       // Requires 4 control points: p0 (before A), p1 (A), p2 (B), p3 (after B)
@@ -544,12 +591,8 @@ bool DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
       if (!canUseCatmullRom) {
         // Not enough points for Catmull-Rom, fall back to linear
         debugln(F("Catmull-Rom: insufficient control points, using linear fallback"));
-
-        double deltaLat = entryB.lat - entryA.lat;
-        double deltaLon = entryB.lng - entryA.lng;
-
-        crossingLat = entryA.lat + t * deltaLat;
-        crossingLng = entryA.lng + t * deltaLon;
+        crossingLat = linearLat;
+        crossingLng = linearLng;
       } else {
         // We have 4 valid control points for Catmull-Rom
         int index0 = crossingIndexA - 1;
@@ -574,9 +617,6 @@ bool DovesLapTimer::interpolateCrossingPoint(double& crossingLat, double& crossi
     }
     return true;
   }
-
-  debugln(F("~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~ INVALID CROSSING ~~~"));
-  return false;
 }
 
 /////////// direction detection
@@ -796,6 +836,7 @@ void DovesLapTimer::reset() {
   positionPrevAlt = 0;
   firstPositionReceived = false;
   consecutiveJumpCount = 0;
+  rejectedCrossingCount = 0;
   prevFixLat = 0;
   prevFixLng = 0;
   prevFixTime = 0;
@@ -921,7 +962,7 @@ float DovesLapTimer::getCurrentSpeedKmh() const {
   return currentSpeedkmh;
 }
 float DovesLapTimer::getCurrentSpeedMph() const {
-  return currentSpeedkmh / 1.60934f;
+  return currentSpeedkmh * GEOMATH_KMH_TO_MPH;
 }
 
 /////////// sector timing getters
@@ -968,6 +1009,9 @@ bool DovesLapTimer::areSectorLinesConfigured() const {
 }
 bool DovesLapTimer::isStartFinishLineConfigured() const {
   return startFinishLineConfigured;
+}
+unsigned int DovesLapTimer::getRejectedCrossingCount() const {
+  return rejectedCrossingCount;
 }
 
 /////////// direction detection getters

--- a/src/DovesLapTimer.h
+++ b/src/DovesLapTimer.h
@@ -10,7 +10,20 @@
 #define _DOVES_LAP_TIMER_H
 
 #include "ArxTypeTraits.h"
+#include "GeoMath.h"
 using TRITYPE = double;
+
+// On classic AVR (Mega, Uno) `double` is a 32-bit float (~7 significant
+// digits). At real-world latitudes/longitudes that quantizes position to
+// roughly 0.2-0.75 m and pushes per-fix haversine half-angle differences
+// below float precision: lap *counting* still works (the 7 m crossing
+// threshold absorbs it) but odometer increments and crossing interpolation
+// carry large relative error. The full advertised precision requires a
+// target with true 64-bit double (nRF52840, ESP32, SAMD51, RP2040, ...).
+// See README "Hardware" notes.
+#if defined(__SIZEOF_DOUBLE__) && (__SIZEOF_DOUBLE__ < 8)
+#warning "DovesLapTimer: 'double' is only 32 bits on this target (classic AVR). Lap counting works but GPS math runs degraded - distances and interpolated crossing times will be noticeably less accurate. Use a 64-bit-double MCU (e.g. XIAO nRF52840) for full precision."
+#endif
 
 #define CROSSING_LINE_SIDE_A -1
 #define CROSSING_LINE_SIDE_EXACT 0
@@ -22,12 +35,22 @@ using TRITYPE = double;
 #define COURSE_DETECT_MIN_DISTANCE_METERS  200.0
 #define COURSE_DETECT_DISTANCE_TOLERANCE_PCT  0.25
 #define COURSE_DETECT_MAX_REJECTIONS  3
-#define METERS_TO_FEET  3.28084
+// Completed proximity passes (full laps back at the waypoint) that matched
+// no configured course length before CourseManager falls back to Lap
+// Anything. Without this, a wrong/missing course config left detection in
+// WAYPOINT_SET forever while the WaypointLapTimer's laps were never surfaced.
+#define COURSE_DETECT_MAX_NO_MATCH_PASSES  3
+// Distance failsafe: if detection is still incomplete after driving
+// factor x (longest configured course length), or the floor below for very
+// short courses, fall back to Lap Anything. Catches the "never returns to
+// within 10m of the waypoint" hang that pass counting can't see.
+#define COURSE_DETECT_FALLBACK_DISTANCE_FACTOR  4.0
+#define COURSE_DETECT_FALLBACK_MIN_METERS  2000.0
+#define METERS_TO_FEET  GEOMATH_METERS_TO_FEET
 
 // Waypoint lap timer constants
 #define WAYPOINT_LAP_MIN_DISTANCE_METERS  100.0
 #define WAYPOINT_LAP_PROXIMITY_METERS  30.0
-#define WAYPOINT_LAP_BUFFER_SIZE  50
 
 // Direction detection
 #define DIR_UNKNOWN  0
@@ -58,6 +81,11 @@ using TRITYPE = double;
 // a crossing line. A larger gap means the GPS time base stepped (e.g. u-blox
 // re-acquisition) and the pair cannot be interpolated coherently.
 #define CROSSING_MAX_FIX_GAP_MS  10000UL
+
+// The straddling pair's summed distance to the line is validated against
+// max(crossingThresholdMeters, factor * pair spacing) so that low-rate GPS
+// (widely spaced fixes) doesn't fail validation purely on sample density.
+#define CROSSING_PAIR_SPACING_FACTOR  1.25
 
 /**
  * @brief Elapsed milliseconds between two milliseconds-since-midnight timestamps.
@@ -184,9 +212,10 @@ public:
    *
    * This function takes the coordinates of a point (pointX, pointY) and a line segment
    * defined by two endpoints (startX, startY) and (endX, endY), and returns the shortest
-   * distance between the point and the line segment. The distance is calculated
-   * in the same unit as the input coordinates (e.g., degrees for latitude and
-   * longitude values).
+   * distance between the point and the line segment. Inputs are decimal-degree
+   * coordinates; the projection onto the segment happens in degree space, but
+   * every return path measures the final distance via haversine, so the
+   * result is in **meters**.
    *
    * @param pointX The x-coordinate of the point.
    * @param pointY The y-coordinate of the point.
@@ -194,7 +223,7 @@ public:
    * @param startY The y-coordinate of the first endpoint of the line segment.
    * @param endX The x-coordinate of the second endpoint of the line segment.
    * @param endY The y-coordinate of the second endpoint of the line segment.
-   * @return The shortest distance between the point and the line segment.
+   * @return The shortest distance between the point and the line segment, in meters.
    */
   double pointLineSegmentDistance(double pointX, double pointY, double startX, double startY, double endX, double endY);
   /**
@@ -364,11 +393,15 @@ public:
    */
   int getLaps() const;
   /**
-   * @brief Calculates the pace difference between the current lap and the best lap in milliseconds.
+   * @brief Calculates the pace difference between the current lap and the best lap.
    *
-   * This function computes the pace for both the current lap and the best lap, and returns the difference.
-   * A positive value indicates that the current lap's pace is slower than the best lap's pace, while a negative
-   * value indicates that the current lap's pace is faster.
+   * Pace is time over distance, so the returned delta is in **milliseconds
+   * per meter** (current lap pace minus best lap pace) — multiply by the
+   * remaining lap distance for a projected time gap. A positive value means
+   * the current lap is running slower than the best lap's pace, negative
+   * means faster. Returns 0 until both laps have distance recorded.
+   *
+   * @return Pace delta in milliseconds per meter.
    */
   float getPaceDifference() const;
   /**
@@ -460,6 +493,19 @@ public:
    * @return True if both sector 2 and sector 3 lines are configured, false otherwise.
    */
   bool areSectorLinesConfigured() const;
+  /**
+   * @brief Number of crossing-zone exits whose interpolation was rejected.
+   *
+   * A rejection means the GPS data inside the zone never produced a usable
+   * straddling pair (no side change, pair too far from the line, incoherent
+   * timestamps, or crossing landing off the line segment). A steadily
+   * climbing count with a non-incrementing lap counter is the signature of
+   * a misplaced line or an unsuitable GPS setup — previously this failure
+   * was visible only on debug serial.
+   *
+   * @return Count of rejected crossings since construction or reset().
+   */
+  unsigned int getRejectedCrossingCount() const;
   /**
    * @brief Checks if the start/finish line is configured.
    *
@@ -681,6 +727,9 @@ private:
 
   // Consecutive fixes rejected for jumping > GPS_MAX_PLAUSIBLE_JUMP_METERS
   int consecutiveJumpCount = 0;
+
+  // Zone exits whose crossing interpolation was rejected (see getter docs)
+  unsigned int rejectedCrossingCount = 0;
 
   // Earth's radius in meters
   static constexpr double radiusEarth = 6371.0 * 1000;

--- a/src/GeoMath.h
+++ b/src/GeoMath.h
@@ -24,6 +24,17 @@
 
 static const double GEOMATH_RADIUS_EARTH = 6371.0 * 1000; // meters
 
+// Unit conversion constants — the single source of truth for the unit
+// boundaries the public API spans (knots from NMEA, km/h internally, mph
+// for the US-facing speed gates, feet for course lengths). One nautical
+// mile is exactly 1852 m and one statute mile exactly 1609.344 m, so the
+// derived factors below stay mutually consistent (previously three
+// hand-typed literals disagreed at the 7th digit).
+static constexpr double GEOMATH_KNOTS_TO_KMH  = 1.852;
+static constexpr double GEOMATH_MPH_TO_KMH    = 1.609344;
+static constexpr double GEOMATH_KMH_TO_MPH    = 1.0 / GEOMATH_MPH_TO_KMH;
+static constexpr double GEOMATH_METERS_TO_FEET = 1.0 / 0.3048; // 1 ft = 0.3048 m exactly
+
 /**
  * @brief Checks a value is a real, finite number (not NaN, not +/-infinity).
  *

--- a/src/WaypointLapTimer.cpp
+++ b/src/WaypointLapTimer.cpp
@@ -45,7 +45,7 @@ void WaypointLapTimer::_resetState() {
   _bestLapNumber = 0;
   _laps = 0;
 
-  _clearProximityBuffer();
+  _resetClosestApproach();
 }
 
 void WaypointLapTimer::updateCurrentTime(unsigned long currentTimeMilliseconds) {
@@ -84,7 +84,7 @@ int WaypointLapTimer::loop(double currentLat, double currentLng, float currentAl
 
   _positionPrevLat = currentLat;
   _positionPrevLng = currentLng;
-  _currentSpeedKmh = currentSpeedKnots * 1.852;
+  _currentSpeedKmh = currentSpeedKnots * GEOMATH_KNOTS_TO_KMH;
 
   // State machine
   if (_state == WLT_STATE_IDLE) {
@@ -100,7 +100,7 @@ int WaypointLapTimer::loop(double currentLat, double currentLng, float currentAl
   }
 
   if (_state == WLT_STATE_IN_PROXIMITY) {
-    _bufferProximityPoint(currentLat, currentLng);
+    _updateProximity(currentLat, currentLng);
   }
 
   return -1;
@@ -119,7 +119,7 @@ void WaypointLapTimer::setProximityMeters(float meters) {
 }
 
 void WaypointLapTimer::_checkSpeed(double lat, double lng) {
-  float speedMph = _currentSpeedKmh * 0.621371;
+  float speedMph = _currentSpeedKmh * GEOMATH_KMH_TO_MPH;
 
   if (speedMph >= _speedThresholdMph) {
     _waypointLat = lat;
@@ -144,36 +144,24 @@ void WaypointLapTimer::_checkProximity(double lat, double lng) {
   if (distToWp < _proximityMeters) {
     _state = WLT_STATE_IN_PROXIMITY;
     _crossing = true;
-    _clearProximityBuffer();
-    _bufferProximityPoint(lat, lng);
+    _resetClosestApproach();
+    _updateProximity(lat, lng);
     debugln(F("Entered waypoint proximity"));
   }
 }
 
-void WaypointLapTimer::_bufferProximityPoint(double lat, double lng) {
+void WaypointLapTimer::_updateProximity(double lat, double lng) {
   double distToWp = geoHaversine(lat, lng, _waypointLat, _waypointLng);
 
   // Check if we've exited proximity
   if (distToWp >= _proximityMeters) {
     _state = WLT_STATE_DRIVING;
     _crossing = false;
-    _processProximityBuffer();
+    _finalizeProximityPass();
     return;
   }
 
-  // Buffer this point
-  int idx = _proximityBufferIndex % WAYPOINT_LAP_BUFFER_SIZE;
-  _proximityBuffer[idx].lat = lat;
-  _proximityBuffer[idx].lng = lng;
-  _proximityBuffer[idx].time = _millisecondsSinceMidnight;
-  _proximityBuffer[idx].odometer = _totalDistanceTraveled;
-  _proximityBuffer[idx].distToWaypoint = distToWp;
-  _proximityBufferIndex++;
-  if (_proximityBufferCount < WAYPOINT_LAP_BUFFER_SIZE) {
-    _proximityBufferCount++;
-  }
-
-  // Track closest approach
+  // Track closest approach — the lap split needs only this
   if (distToWp < _closestDist) {
     _closestDist = distToWp;
     _closestTime = _millisecondsSinceMidnight;
@@ -181,16 +169,16 @@ void WaypointLapTimer::_bufferProximityPoint(double lat, double lng) {
   }
 }
 
-void WaypointLapTimer::_clearProximityBuffer() {
-  _proximityBufferIndex = 0;
-  _proximityBufferCount = 0;
+void WaypointLapTimer::_resetClosestApproach() {
   _closestDist = INFINITY;
   _closestTime = 0;
   _closestOdometer = 0;
 }
 
-void WaypointLapTimer::_processProximityBuffer() {
-  if (_closestTime == 0) {
+void WaypointLapTimer::_finalizeProximityPass() {
+  // _closestDist is the "was anything recorded" sentinel — a timestamp of 0
+  // is a legitimate closest approach at exactly 00:00:00.000 UTC.
+  if (_closestDist == INFINITY) {
     debugln(F("No valid closest point found"));
     return;
   }
@@ -303,7 +291,7 @@ float WaypointLapTimer::getCurrentSpeedKmh() const {
 }
 
 float WaypointLapTimer::getCurrentSpeedMph() const {
-  return _currentSpeedKmh / 1.60934f;
+  return _currentSpeedKmh * GEOMATH_KMH_TO_MPH;
 }
 
 float WaypointLapTimer::getLastLapDistance() const {

--- a/src/WaypointLapTimer.h
+++ b/src/WaypointLapTimer.h
@@ -26,14 +26,6 @@
 #define WLT_STATE_DRIVING        2
 #define WLT_STATE_IN_PROXIMITY   3
 
-struct ProximityBufferEntry {
-  double lat;
-  double lng;
-  unsigned long time;
-  float odometer;
-  float distToWaypoint;
-};
-
 class WaypointLapTimer {
 public:
   WaypointLapTimer(Stream *debugSerial = NULL);
@@ -97,9 +89,9 @@ private:
   void _resetState();
   void _checkSpeed(double lat, double lng);
   void _checkProximity(double lat, double lng);
-  void _bufferProximityPoint(double lat, double lng);
-  void _clearProximityBuffer();
-  void _processProximityBuffer();
+  void _updateProximity(double lat, double lng);
+  void _resetClosestApproach();
+  void _finalizeProximityPass();
 
   Stream *_serial;
 
@@ -133,10 +125,10 @@ private:
   int _bestLapNumber;
   int _laps;
 
-  // Proximity buffer
-  ProximityBufferEntry _proximityBuffer[WAYPOINT_LAP_BUFFER_SIZE];
-  int _proximityBufferIndex;
-  int _proximityBufferCount;
+  // Closest approach to the waypoint during the current proximity pass.
+  // Only these three scalars are needed for the lap split — the old
+  // 50-entry buffer of every in-proximity fix was written and never read
+  // (1.6 KB of dead SRAM per instance).
   float _closestDist;
   unsigned long _closestTime;
   float _closestOdometer;

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,9 +30,19 @@ LIB_SRCS = ../src/DovesLapTimer.cpp \
 TEST_SRCS = $(wildcard test_*.cpp)
 TEST_BINS = $(TEST_SRCS:%.cpp=build/%)
 
+# Every header any test could pull in. Listing them as prerequisites is
+# deliberately coarse (any header edit rebuilds everything — the suite
+# builds in seconds) but it closes the false-green hole where `make run`
+# passed on binaries that were stale against ../src/*.h, replay_runner.h,
+# or the NMEA fixture headers.
+HEADERS = $(wildcard ../src/*.h) \
+          $(wildcard ../examples/real_track_data_debug/*.h) \
+          $(wildcard mock/*.h) \
+          test_runner.h replay_runner.h
+
 all: $(TEST_BINS)
 
-build/%: %.cpp $(LIB_SRCS) test_runner.h mock/Arduino.h mock/ArxTypeTraits.h
+build/%: %.cpp $(LIB_SRCS) $(HEADERS)
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) -o $@ $< $(LIB_SRCS) $(LDFLAGS)
 
@@ -58,13 +68,15 @@ clean:
 # ----- Coverage -----
 # Instruments the library sources, runs every test binary (gcda accumulates
 # across them), and summarizes line coverage of ../src/ with gcovr. Fails if
-# below COVERAGE_GATE percent. The gate starts intentionally low — raise it
-# as coverage grows. Override on the command line: `make coverage COVERAGE_GATE=40`.
-COVERAGE_GATE ?= 1
+# below COVERAGE_GATE percent. The gate sits just below measured coverage
+# (84.5% line as of 2026-06-11) so any change that meaningfully drops
+# coverage fails CI — keep ratcheting it up alongside new tests.
+# Override on the command line: `make coverage COVERAGE_GATE=40`.
+COVERAGE_GATE ?= 80
 COV_DIR        = coverage
 COV_BINS       = $(TEST_SRCS:%.cpp=$(COV_DIR)/%)
 
-$(COV_DIR)/%: %.cpp $(LIB_SRCS) test_runner.h mock/Arduino.h mock/ArxTypeTraits.h
+$(COV_DIR)/%: %.cpp $(LIB_SRCS) $(HEADERS)
 	@mkdir -p $(COV_DIR)
 	$(CXX) $(CXXFLAGS) --coverage -o $@ $< $(LIB_SRCS) $(LDFLAGS)
 

--- a/test/README.md
+++ b/test/README.md
@@ -17,6 +17,9 @@ DovesLapTimer. Compiles and runs on Linux / macOS with `g++` or `clang++`
 | `test_midnight_rollover` | time-base handling | lap / sector / crossing-zone timing across the UTC midnight wrap, `timeSinceMidnightDelta` (CLAUDE.md issue #15) |
 | `test_input_validation` | GPS input guards | NaN/Inf/(0,0)/out-of-range rejection, teleport drop + relocation re-seed, unconfigured / degenerate line safety (issues #14 / #17) |
 | `test_buffer_wraparound` | crossing-buffer ring | parked-in-zone wraparound: park-cross-park and standing-start scenarios (issue #18) |
+| `test_low_rate_gps` | crossing validation | 1 Hz / 5 Hz crossing detection, spacing-scaled validation, `getRejectedCrossingCount()` surfacing (issue #20) |
+| `test_waypoint_lap_timer` | `WaypointLapTimer.h/cpp` | waypoint drop, closest-approach lap splits on a 400m circle, lap accounting, reset semantics |
+| `test_course_manager` | `CourseManager.h/cpp` | detection accept/reject, no-match + distance-failsafe fallbacks (issue #21), Lap-Anything timer deactivation, prune, reset |
 
 ### Layer 3 — NMEA replay regression
 

--- a/test/test_course_manager.cpp
+++ b/test/test_course_manager.cpp
@@ -1,0 +1,300 @@
+/**
+ * Layer-2 tests for CourseManager orchestration — review issues H5, H7, H11.
+ *
+ * Drives the full detect/validate/accept/reject/fallback flow on the
+ * synthetic 100m x 100m square track (400m lap, ~1312 ft):
+ *
+ *   - candidate accept via the raceStarted sanity check
+ *   - reject -> Lap Anything after MAX_REJECTIONS (issue #13 exercised
+ *     through CourseManager, where the original bug manifested)
+ *   - H5: no-match passes -> Lap Anything (config lists no matching length)
+ *   - H5: distance failsafe -> Lap Anything (driver never re-enters
+ *     waypoint proximity)
+ *   - H7: Lap Anything activation deactivates every course timer
+ *   - pruneInactiveCourses() deactivates non-detected timers
+ */
+
+#include "test_runner.h"
+#include "../src/CourseManager.h"
+
+static constexpr double TRACK_SOUTH_LAT = 28.41265;
+static constexpr double TRACK_NORTH_LAT = 28.41355;
+static constexpr double TRACK_WEST_LNG  = -81.37970;
+static constexpr double TRACK_EAST_LNG  = -81.37870;
+static constexpr unsigned int  STEPS_PER_LAP = 80;   // 5m per step, 400m lap
+static constexpr unsigned long MS_PER_STEP   = 200;
+static constexpr float SPEED_KNOTS = 48.0f;          // ~55 mph
+static constexpr float ALT = 50.0f;
+static constexpr float LAP_LENGTH_FT = 1312.34f;     // 400m
+
+// S/F line on the south side — crossed every lap
+static constexpr double SF_A_LAT = 28.41255, SF_A_LNG = -81.37920;
+static constexpr double SF_B_LAT = 28.41275, SF_B_LNG = -81.37920;
+
+static void generateSyntheticFix(unsigned long step, double &lat, double &lng) {
+  const unsigned int sideSteps = STEPS_PER_LAP / 4;
+  const unsigned int phase = step % STEPS_PER_LAP;
+  const double t = (phase % sideSteps) / (double)sideSteps;
+
+  if (phase < sideSteps) {
+    lat = TRACK_SOUTH_LAT;
+    lng = TRACK_WEST_LNG + t * (TRACK_EAST_LNG - TRACK_WEST_LNG);
+  } else if (phase < 2 * sideSteps) {
+    lat = TRACK_SOUTH_LAT + t * (TRACK_NORTH_LAT - TRACK_SOUTH_LAT);
+    lng = TRACK_EAST_LNG;
+  } else if (phase < 3 * sideSteps) {
+    lat = TRACK_NORTH_LAT;
+    lng = TRACK_EAST_LNG + t * (TRACK_WEST_LNG - TRACK_EAST_LNG);
+  } else {
+    lat = TRACK_NORTH_LAT + t * (TRACK_SOUTH_LAT - TRACK_NORTH_LAT);
+    lng = TRACK_WEST_LNG;
+  }
+}
+
+static void driveLaps(CourseManager &mgr, unsigned long steps) {
+  for (unsigned long step = 0; step < steps; step++) {
+    double lat, lng;
+    generateSyntheticFix(step, lat, lng);
+    mgr.updateCurrentTime(1000 + step * MS_PER_STEP);
+    mgr.loop(lat, lng, ALT, SPEED_KNOTS);
+  }
+}
+
+// A course whose length matches the synthetic lap and whose S/F line is
+// genuinely crossed -> passes the raceStarted sanity check.
+static CourseConfig matchingCourse(const char *name) {
+  CourseConfig c = {};
+  c.name = name;
+  c.lengthFt = LAP_LENGTH_FT;
+  c.startALat = SF_A_LAT; c.startALng = SF_A_LNG;
+  c.startBLat = SF_B_LAT; c.startBLng = SF_B_LNG;
+  c.hasSector2 = false;
+  c.hasSector3 = false;
+  return c;
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+void test_zero_courses_activates_lap_anything_immediately() {
+  TrackConfig cfg = {};
+  cfg.longName = "Empty";
+  cfg.shortName = "E";
+  cfg.courseCount = 0;
+
+  CourseManager mgr(cfg);
+  EXPECT_TRUE(mgr.isDetectionComplete());
+  EXPECT_TRUE(mgr.isLapAnythingActive());
+}
+
+// =============================================================================
+// Detection accept (raceStarted sanity check passes)
+// =============================================================================
+
+void test_detection_accepts_matching_course() {
+  TrackConfig cfg = {};
+  cfg.longName = "Synthetic";
+  cfg.shortName = "SYN";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Square 400m");
+
+  CourseManager mgr(cfg);
+  driveLaps(mgr, STEPS_PER_LAP + 30);  // one lap back to the waypoint + slack
+
+  EXPECT_TRUE(mgr.isDetectionComplete());
+  EXPECT_FALSE(mgr.isLapAnythingActive());
+  EXPECT_EQ(mgr.getActiveCourseIndex(), 0);
+  EXPECT_TRUE(mgr.getActiveTimer() != NULL);
+  EXPECT_TRUE(strcmp(mgr.getActiveCourseName(), "Square 400m") == 0);
+}
+
+void test_active_timer_keeps_lapping_after_detection() {
+  TrackConfig cfg = {};
+  cfg.longName = "Synthetic";
+  cfg.shortName = "SYN";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Square 400m");
+
+  CourseManager mgr(cfg);
+  driveLaps(mgr, 3 * STEPS_PER_LAP + 30);
+
+  DovesLapTimer *timer = mgr.getActiveTimer();
+  EXPECT_TRUE(timer != NULL);
+  EXPECT_TRUE(timer->getLaps() >= 2);
+  EXPECT_NEAR(timer->getLastLapTime(), STEPS_PER_LAP * MS_PER_STEP, 100.0);
+}
+
+// =============================================================================
+// Reject path -> Lap Anything (issue #13 exercised through CourseManager)
+// =============================================================================
+
+void test_rejections_fall_back_to_lap_anything() {
+  // Length matches so candidates ARE produced, but the S/F line is far off
+  // track -> raceStarted never true -> every candidate set is rejected.
+  TrackConfig cfg = {};
+  cfg.longName = "WrongLine";
+  cfg.shortName = "WL";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Ghost Course");
+  cfg.courses[0].startALat = SF_A_LAT + 1.0;  // ~111km away, never crossed
+  cfg.courses[0].startBLat = SF_B_LAT + 1.0;
+
+  CourseManager mgr(cfg);
+  // Each rejection re-anchors the detector's lap window, so one rejection
+  // per lap: 3 laps to exhaust the budget, plus slack.
+  driveLaps(mgr, 5 * STEPS_PER_LAP);
+
+  EXPECT_EQ(mgr.getDetectionRejectionCount(), COURSE_DETECT_MAX_REJECTIONS);
+  EXPECT_TRUE(mgr.isLapAnythingActive());
+  EXPECT_TRUE(mgr.isDetectionComplete());
+  EXPECT_TRUE(mgr.getActiveTimer() == NULL);
+}
+
+// =============================================================================
+// H5 — no-match passes reach the fallback (previously hung forever)
+// =============================================================================
+
+void test_no_match_config_falls_back_to_lap_anything() {
+  // Configured length is 10000 ft (~3km); driven laps are ~1312 ft. The
+  // detector never produces candidates, so the rejection counter never
+  // moves — pre-fix, detection sat in WAYPOINT_SET forever and
+  // getActiveTimer() stayed NULL while WaypointLapTimer's laps were unseen.
+  TrackConfig cfg = {};
+  cfg.longName = "WrongLength";
+  cfg.shortName = "WLN";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Mismatched Course");
+  cfg.courses[0].lengthFt = 10000.0f;
+
+  CourseManager mgr(cfg);
+  driveLaps(mgr, 5 * STEPS_PER_LAP);
+
+  EXPECT_TRUE(mgr.isLapAnythingActive());
+  EXPECT_TRUE(mgr.isDetectionComplete());
+  EXPECT_EQ(mgr.getDetectionRejectionCount(), 0);  // proves the no-match path
+  EXPECT_TRUE(mgr.getDetector()->getNoMatchCount() >= COURSE_DETECT_MAX_NO_MATCH_PASSES);
+  // The fallback timer was timing laps all along and is now surfaced
+  EXPECT_TRUE(mgr.getLapAnythingTimer()->getLaps() >= 1);
+}
+
+void test_distance_failsafe_falls_back_when_waypoint_never_revisited() {
+  // Drive a straight line: the detector drops a waypoint and the driver
+  // never comes back, so neither candidates nor no-match passes ever
+  // happen. Only the odometer failsafe can unhang this.
+  TrackConfig cfg = {};
+  cfg.longName = "Straight";
+  cfg.shortName = "STR";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Unreachable Course");
+
+  CourseManager mgr(cfg);
+  // failsafe = max(2000m, 4 x 400m) = 2000m; drive 2300m east in 5m steps
+  const double mPerDegLng = 111320.0 * cos(TRACK_SOUTH_LAT * M_PI / 180.0);
+  for (unsigned long step = 0; step < 460; step++) {
+    double lng = TRACK_WEST_LNG + (step * 5.0) / mPerDegLng;
+    mgr.updateCurrentTime(1000 + step * MS_PER_STEP);
+    mgr.loop(TRACK_SOUTH_LAT, lng, ALT, SPEED_KNOTS);
+  }
+
+  EXPECT_TRUE(mgr.isLapAnythingActive());
+  EXPECT_TRUE(mgr.isDetectionComplete());
+  EXPECT_EQ(mgr.getDetectionRejectionCount(), 0);
+  EXPECT_EQ(mgr.getDetector()->getNoMatchCount(), 0);
+}
+
+// =============================================================================
+// H7 — Lap Anything activation stops feeding all course timers
+// =============================================================================
+
+void test_lap_anything_deactivates_all_course_timers() {
+  TrackConfig cfg = {};
+  cfg.longName = "WrongLength";
+  cfg.shortName = "WLN";
+  cfg.courseCount = 3;
+  cfg.courses[0] = matchingCourse("A");
+  cfg.courses[1] = matchingCourse("B");
+  cfg.courses[2] = matchingCourse("C");
+  for (int i = 0; i < 3; i++) cfg.courses[i].lengthFt = 10000.0f;  // never match
+
+  CourseManager mgr(cfg);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_TRUE(mgr.isCourseTimerActive(i));  // all fed before fallback
+  }
+
+  driveLaps(mgr, 5 * STEPS_PER_LAP);
+
+  EXPECT_TRUE(mgr.isLapAnythingActive());
+  for (int i = 0; i < 3; i++) {
+    EXPECT_FALSE(mgr.isCourseTimerActive(i));  // none fed after fallback
+  }
+}
+
+// =============================================================================
+// pruneInactiveCourses
+// =============================================================================
+
+void test_prune_deactivates_non_detected_courses() {
+  TrackConfig cfg = {};
+  cfg.longName = "TwoLayouts";
+  cfg.shortName = "2L";
+  cfg.courseCount = 2;
+  cfg.courses[0] = matchingCourse("Right Layout");
+  cfg.courses[1] = matchingCourse("Wrong Layout");
+  cfg.courses[1].lengthFt = 5000.0f;  // outside tolerance, never a candidate
+
+  CourseManager mgr(cfg);
+  driveLaps(mgr, STEPS_PER_LAP + 30);
+  EXPECT_EQ(mgr.getActiveCourseIndex(), 0);
+  EXPECT_TRUE(mgr.isCourseTimerActive(1));  // still fed until pruned
+
+  mgr.pruneInactiveCourses();
+  EXPECT_TRUE(mgr.isCourseTimerActive(0));
+  EXPECT_FALSE(mgr.isCourseTimerActive(1));
+  EXPECT_TRUE(mgr.getActiveTimer() != NULL);
+}
+
+// =============================================================================
+// reset
+// =============================================================================
+
+void test_reset_restores_detection_state() {
+  TrackConfig cfg = {};
+  cfg.longName = "Synthetic";
+  cfg.shortName = "SYN";
+  cfg.courseCount = 1;
+  cfg.courses[0] = matchingCourse("Square 400m");
+
+  CourseManager mgr(cfg);
+  driveLaps(mgr, STEPS_PER_LAP + 30);
+  EXPECT_TRUE(mgr.isDetectionComplete());
+
+  mgr.reset();
+  EXPECT_FALSE(mgr.isDetectionComplete());
+  EXPECT_FALSE(mgr.isLapAnythingActive());
+  EXPECT_TRUE(mgr.getActiveTimer() == NULL);
+  EXPECT_TRUE(mgr.isCourseTimerActive(0));
+  EXPECT_EQ(mgr.getDetector()->getNoMatchCount(), 0);
+}
+
+int main() {
+  printf("=== CourseManager tests ===\n");
+
+  RUN_TEST(zero_courses_activates_lap_anything_immediately);
+
+  RUN_TEST(detection_accepts_matching_course);
+  RUN_TEST(active_timer_keeps_lapping_after_detection);
+
+  RUN_TEST(rejections_fall_back_to_lap_anything);
+
+  RUN_TEST(no_match_config_falls_back_to_lap_anything);
+  RUN_TEST(distance_failsafe_falls_back_when_waypoint_never_revisited);
+
+  RUN_TEST(lap_anything_deactivates_all_course_timers);
+
+  RUN_TEST(prune_deactivates_non_detected_courses);
+
+  RUN_TEST(reset_restores_detection_state);
+
+  TEST_SUMMARY();
+}

--- a/test/test_low_rate_gps.cpp
+++ b/test/test_low_rate_gps.cpp
@@ -1,0 +1,133 @@
+/**
+ * Layer-2 tests for low-sample-rate GPS crossing detection — review issue H4.
+ *
+ * The old crossing validation required the straddle pair's summed distance
+ * to the line to be under crossingThresholdMeters in absolute meters. That
+ * conflates zone size with sample density: at 1 Hz / ~70 km/h consecutive
+ * fixes are ~19 m apart, every genuine crossing failed the check, and the
+ * lap counter silently never incremented (the failure went only to debug
+ * serial). Validation now scales with the pair's own spacing, the exiting
+ * fix is included in the buffer so a straddle pair exists at all, and
+ * rejected crossings are surfaced via getRejectedCrossingCount().
+ *
+ * Geometry: S/F line spans lat 28.41255..28.41275 at lng -81.37920; the
+ * driver moves only in longitude, perpendicular through the line.
+ */
+
+#include "test_runner.h"
+#include "../src/DovesLapTimer.h"
+
+static constexpr double SF_A_LAT = 28.41255, SF_A_LNG = -81.37920;
+static constexpr double SF_B_LAT = 28.41275, SF_B_LNG = -81.37920;
+static constexpr double DRIVER_LAT = 28.41265;          // line midpoint
+static constexpr double LNG_PER_METER = 1.0 / 97924.0;  // at this latitude
+static constexpr float ALT = 50.0f;
+
+static void feedFix(DovesLapTimer &t, double metersEastOfLine,
+                    float speedKnots, unsigned long timeMs) {
+  t.updateCurrentTime(timeMs);
+  t.loop(DRIVER_LAT, SF_A_LNG + metersEastOfLine * LNG_PER_METER, ALT, speedKnots);
+}
+
+// =============================================================================
+// 1 Hz crossing: 19m between fixes, threshold widened to 15m as a 1 Hz
+// user would. Pre-fix the straddle pair's 19m sum always failed the 15m
+// absolute bound -> zero laps forever.
+// =============================================================================
+
+void test_one_hz_crossing_detected() {
+  DovesLapTimer timer(15.0);  // enlarged zone, appropriate for 1 Hz
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+
+  // ~70 km/h at 1 Hz = 19m per fix, perpendicular through the line.
+  // Two passes: first arms raceStarted, second completes a lap.
+  const float speedKnots = 37.0f;  // ~68.5 km/h
+  unsigned long t = 10000;
+  for (int pass = 0; pass < 2; pass++) {
+    for (double m = -47.5; m <= 50.0; m += 19.0) {
+      feedFix(timer, m, speedKnots, t);
+      t += 1000;
+    }
+    // teleport-guard-friendly return trip: come back through the line
+    if (pass == 0) {
+      for (double m = 50.0 - 19.0 / 2; m >= -50.0; m -= 19.0) {
+        feedFix(timer, m, speedKnots, t);
+        t += 1000;
+      }
+    }
+  }
+
+  EXPECT_TRUE(timer.getRaceStarted());
+  EXPECT_TRUE(timer.getLaps() >= 1);
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 0U);
+}
+
+void test_five_hz_crossing_detected_with_default_threshold() {
+  // 5 Hz / ~70 km/h = ~3.8m spacing — must work with the stock 7m zone.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+
+  unsigned long t = 10000;
+  for (double m = -19.0; m <= 19.0; m += 3.8) {
+    feedFix(timer, m, 37.0f, t);
+    t += 200;
+  }
+
+  EXPECT_TRUE(timer.getRaceStarted());
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 0U);
+}
+
+// =============================================================================
+// Rejected crossings are surfaced, not silent
+// =============================================================================
+
+void test_rejected_crossing_increments_counter() {
+  // Drive into the zone and back out the same side: a zone exit with no
+  // side change can't be interpolated. Previously this was visible only
+  // on debug serial; now the public counter records it.
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+
+  unsigned long t = 10000;
+  feedFix(timer, -20.0, 20.0f, t);  t += 200;
+  feedFix(timer, -5.0,  20.0f, t);  t += 200;  // enters zone, west side
+  feedFix(timer, -3.0,  20.0f, t);  t += 200;  // still west
+  feedFix(timer, -20.0, 20.0f, t);  t += 200;  // U-turn, exits same side
+
+  EXPECT_FALSE(timer.getRaceStarted());
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 1U);
+
+  // A genuine crossing afterwards still works and doesn't bump the counter
+  for (double m = -20.0; m <= 20.0; m += 4.0) {
+    feedFix(timer, m, 20.0f, t);
+    t += 200;
+  }
+  EXPECT_TRUE(timer.getRaceStarted());
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 1U);
+}
+
+void test_reset_clears_rejected_crossing_counter() {
+  DovesLapTimer timer(7.0);
+  timer.setStartFinishLine(SF_A_LAT, SF_A_LNG, SF_B_LAT, SF_B_LNG);
+
+  unsigned long t = 10000;
+  feedFix(timer, -20.0, 20.0f, t);  t += 200;
+  feedFix(timer, -5.0,  20.0f, t);  t += 200;
+  feedFix(timer, -20.0, 20.0f, t);  t += 200;
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 1U);
+
+  timer.reset();
+  EXPECT_EQ(timer.getRejectedCrossingCount(), 0U);
+}
+
+int main() {
+  printf("=== Low-rate GPS crossing tests ===\n");
+
+  RUN_TEST(one_hz_crossing_detected);
+  RUN_TEST(five_hz_crossing_detected_with_default_threshold);
+
+  RUN_TEST(rejected_crossing_increments_counter);
+  RUN_TEST(reset_clears_rejected_crossing_counter);
+
+  TEST_SUMMARY();
+}

--- a/test/test_waypoint_lap_timer.cpp
+++ b/test/test_waypoint_lap_timer.cpp
@@ -1,0 +1,166 @@
+/**
+ * Layer-2 tests for WaypointLapTimer ("Lap Anything" mode) — review issue H11.
+ *
+ * Drives the proximity state machine end to end: waypoint drop at speed,
+ * closest-approach lap splits on a deterministic 400m circle, lap
+ * accounting (last/best/distance), and reset semantics. Until now this
+ * 300-line module had zero direct tests.
+ */
+
+#include "test_runner.h"
+#include "../src/WaypointLapTimer.h"
+
+static constexpr double CENTER_LAT = 28.41265;
+static constexpr double CENTER_LNG = -81.37920;
+static constexpr double RADIUS_M   = 63.66;       // 2*pi*r ~= 400m lap
+static constexpr unsigned int  STEPS_PER_LAP = 80; // 5m per step
+static constexpr unsigned long MS_PER_STEP   = 200;
+static constexpr float SPEED_FAST_KNOTS = 48.0f;   // ~55 mph, above 20mph gate
+static constexpr float SPEED_SLOW_KNOTS = 5.0f;    // ~5.8 mph, below gate
+static constexpr float ALT = 50.0f;
+
+// Position on the circle at a given step; step 0 = easternmost point.
+static void circleFix(unsigned long step, double &lat, double &lng) {
+  const double mPerDegLat = 111320.0;
+  const double mPerDegLng = 111320.0 * cos(CENTER_LAT * M_PI / 180.0);
+  double theta = (2.0 * M_PI * (step % STEPS_PER_LAP)) / STEPS_PER_LAP;
+  lat = CENTER_LAT + (RADIUS_M * sin(theta)) / mPerDegLat;
+  lng = CENTER_LNG + (RADIUS_M * cos(theta)) / mPerDegLng;
+}
+
+static void driveCircle(WaypointLapTimer &wlt, unsigned long steps,
+                        float speedKnots, unsigned long startTimeMs = 1000) {
+  for (unsigned long step = 0; step < steps; step++) {
+    double lat, lng;
+    circleFix(step, lat, lng);
+    wlt.updateCurrentTime(startTimeMs + step * MS_PER_STEP);
+    wlt.loop(lat, lng, ALT, speedKnots);
+  }
+}
+
+// =============================================================================
+// Waypoint drop
+// =============================================================================
+
+void test_initial_state() {
+  WaypointLapTimer wlt;
+  EXPECT_FALSE(wlt.hasWaypoint());
+  EXPECT_FALSE(wlt.getRaceStarted());
+  EXPECT_EQ(wlt.getLaps(), 0);
+  EXPECT_EQ(wlt.getCurrentLapTime(), 0UL);
+}
+
+void test_no_waypoint_below_speed_threshold() {
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 40, SPEED_SLOW_KNOTS);
+  EXPECT_FALSE(wlt.hasWaypoint());
+  EXPECT_FALSE(wlt.getRaceStarted());
+}
+
+void test_waypoint_drops_at_speed() {
+  WaypointLapTimer wlt;
+  double lat0, lng0;
+  circleFix(0, lat0, lng0);
+
+  wlt.updateCurrentTime(1000);
+  wlt.loop(lat0, lng0, ALT, SPEED_FAST_KNOTS);
+
+  EXPECT_TRUE(wlt.hasWaypoint());
+  EXPECT_NEAR(wlt.getWaypointLat(), lat0, 1e-9);
+  EXPECT_NEAR(wlt.getWaypointLng(), lng0, 1e-9);
+}
+
+// =============================================================================
+// Lap splits via closest approach
+// =============================================================================
+
+void test_laps_counted_on_circle() {
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 3 * STEPS_PER_LAP + 20, SPEED_FAST_KNOTS);
+
+  EXPECT_TRUE(wlt.getRaceStarted());
+  EXPECT_TRUE(wlt.getLaps() >= 3);
+}
+
+void test_lap_time_matches_circle_period() {
+  // Every lap passes exactly through the waypoint; the closest-approach
+  // split lands on the same circle position each time, so lap time must
+  // equal the lap period (80 steps x 200ms).
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 3 * STEPS_PER_LAP + 20, SPEED_FAST_KNOTS);
+
+  EXPECT_NEAR(wlt.getLastLapTime(), STEPS_PER_LAP * MS_PER_STEP, 300.0);
+  EXPECT_NEAR(wlt.getBestLapTime(), STEPS_PER_LAP * MS_PER_STEP, 300.0);
+}
+
+void test_lap_distance_matches_circumference() {
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 3 * STEPS_PER_LAP + 20, SPEED_FAST_KNOTS);
+
+  // 80 chords of a 400m circle ~= 399.7m
+  EXPECT_NEAR(wlt.getLastLapDistance(), 400.0, 20.0);
+  EXPECT_NEAR(wlt.getBestLapDistance(), 400.0, 20.0);
+}
+
+void test_best_lap_number_tracked() {
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 3 * STEPS_PER_LAP + 20, SPEED_FAST_KNOTS);
+
+  int best = wlt.getBestLapNumber();
+  EXPECT_TRUE(best >= 1);
+  EXPECT_TRUE(best <= wlt.getLaps());
+}
+
+void test_crossing_flag_only_inside_proximity() {
+  // Mid-lap (far side of the circle) the crossing flag must be false.
+  WaypointLapTimer wlt;
+  driveCircle(wlt, STEPS_PER_LAP / 2, SPEED_FAST_KNOTS);
+  EXPECT_FALSE(wlt.getCrossing());
+}
+
+// =============================================================================
+// Reset / configuration
+// =============================================================================
+
+void test_reset_clears_timing_state() {
+  WaypointLapTimer wlt;
+  driveCircle(wlt, 2 * STEPS_PER_LAP + 20, SPEED_FAST_KNOTS);
+  EXPECT_TRUE(wlt.getLaps() >= 1);
+
+  wlt.reset();
+  EXPECT_FALSE(wlt.hasWaypoint());
+  EXPECT_FALSE(wlt.getRaceStarted());
+  EXPECT_EQ(wlt.getLaps(), 0);
+  EXPECT_NEAR(wlt.getTotalDistanceTraveled(), 0.0, 0.01);
+}
+
+void test_custom_speed_threshold_survives_reset() {
+  WaypointLapTimer wlt;
+  wlt.setSpeedThresholdMph(100.0f);  // above our 55mph sim speed
+
+  driveCircle(wlt, 10, SPEED_FAST_KNOTS);
+  EXPECT_FALSE(wlt.hasWaypoint());  // custom threshold respected
+
+  wlt.reset();
+  driveCircle(wlt, 10, SPEED_FAST_KNOTS);
+  EXPECT_FALSE(wlt.hasWaypoint());  // threshold survived reset (documented)
+}
+
+int main() {
+  printf("=== WaypointLapTimer tests ===\n");
+
+  RUN_TEST(initial_state);
+  RUN_TEST(no_waypoint_below_speed_threshold);
+  RUN_TEST(waypoint_drops_at_speed);
+
+  RUN_TEST(laps_counted_on_circle);
+  RUN_TEST(lap_time_matches_circle_period);
+  RUN_TEST(lap_distance_matches_circumference);
+  RUN_TEST(best_lap_number_tracked);
+  RUN_TEST(crossing_flag_only_inside_proximity);
+
+  RUN_TEST(reset_clears_timing_state);
+  RUN_TEST(custom_speed_threshold_survives_reset);
+
+  TEST_SUMMARY();
+}


### PR DESCRIPTION
Works through review findings H3–H14 (follows up on #41, which covered C1–C3/H1/H2). All 131 host tests green, coverage gate raised and passing, NMEA replay goldens unchanged. The H4 and H5 regression tests were verified to **fail against the pre-fix code**.

## Code fixes

**H4 — low-rate GPS silently killed lap counting.** The straddle-pair validation no longer compares against the zone size in absolute meters; it scales with the pair's own spacing (`CROSSING_PAIR_SPACING_FACTOR`, 1.25 — geometrically, a genuine straddle's distance sum can never exceed its spacing). The zone-exiting fix is now buffered too, since at 1 Hz the crossing usually happens between the last in-zone fix and the exit fix — without it there's no straddle pair at all. A geometric backstop requires the interpolated point to land on the line *segment* within the threshold (not the infinite extension), and rejected crossings surface through the new `getRejectedCrossingCount()` instead of dying on debug serial. Verified: 1 Hz / ~19 m spacing now counts laps; pre-fix it counted zero, forever, silently.

**H5 — Lap Anything unreachable from the most likely failure mode.** `CourseDetector` counts completed no-match proximity passes (`getNoMatchCount()`); `CourseManager` falls back after `COURSE_DETECT_MAX_NO_MATCH_PASSES` (3). A second, independent failsafe fires when the odometer exceeds 4 × the longest configured course (2000 m floor) — covering drivers who never re-enter the 10 m waypoint zone, which pass counting can't see.

**H7 — Lap Anything left all 8 course timers running forever.** `_activateLapAnything()` now deactivates every course entry. New `isCourseTimerActive(index)` getter for observability.

**H8 — 1.6 KB write-only buffer deleted.** `WaypointLapTimer` keeps only the three closest-approach scalars the lap split ever used; `ProximityBufferEntry` and `WAYPOINT_LAP_BUFFER_SIZE` are gone. Instance size: ~1.8 KB → ~150 B. Also replaced the `_closestTime == 0` validity sentinel (same midnight-bug class fixed in #41) with the `INFINITY` distance sentinel.

**H14 — unit-conversion constants unified.** `GeoMath.h` now owns `GEOMATH_KNOTS_TO_KMH`, `GEOMATH_KMH_TO_MPH`, `GEOMATH_MPH_TO_KMH`, `GEOMATH_METERS_TO_FEET`, derived from the exact nautical/statute-mile definitions. All five scattered literals (`1.852`, `0.621371`, `1.60934` — mutually inconsistent at the 7th digit) replaced; `METERS_TO_FEET` aliases the shared constant.

## Honesty fixes

**H3 — AVR 32-bit double.** A `#warning` now fires on 4-byte-double targets, and the README/CLAUDE.md state plainly: lap counting works on Mega/Uno, but position quantizes at ~0.2–0.75 m and odometer/interpolation accuracy is degraded; full precision needs a real 64-bit-double MCU.

**H6 — memory claims corrected.** Measured: `CourseManager` ≈ 29 KB (host/64-bit double), 28.8 KB of it the by-value 8-slot timer array, allocated regardless of configured course count. Docs now say pruning saves CPU and frees zero bytes, and that `CourseManager` does not fit on AVR Mega. The "~24 KB drops to ~5 KB after pruning" fiction is gone from README and CLAUDE.md.

**H9 — doc lies fixed.** README direction-detection section rewritten to the actual both-sectors temporal-order algorithm; `getPaceDifference()` documented as **ms per meter** in both README and header; `pointLineSegmentDistance()` documented as returning **meters**. A doc-claim spot-check step was added to the release checklist in CONTRIBUTING.md.

## Test & CI fixes

**H10 — Makefile header deps.** All headers (src, mocks, replay runner, NMEA fixtures) are prerequisites of every test binary. The review's exact repro (`touch ../src/DovesLapTimer.h && make` → "Nothing to be done") now rebuilds.

**H11 — the untested modules are tested.** New `test_course_manager.cpp` (9 tests: accept, reject→fallback through CourseManager where issue #13 manifested, both H5 fallbacks, H7 deactivation, prune, reset), `test_waypoint_lap_timer.cpp` (10 tests), `test_low_rate_gps.cpp` (4 tests). Line coverage: ~51% → **84.5%**.

**H13 — coverage gate raised 1% → 80%**, just under measured coverage, so deleting behavioral tests fails CI.

**H12 — CI supply chain.** Every action pinned to a commit SHA verified via `git ls-remote` against the upstream repos (annotated tags peeled to commit SHAs); `peaceiris/actions-gh-pages` bumped v3 → v4 while pinning; `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped) keeps pins fresh; gh-pages/badge deploy steps now require `github.ref == 'refs/heads/master'`, closing the any-branch `workflow_dispatch` overwrite hole.

## Deferred items / decisions for you

These came up during the work and are intentionally **not** in this PR — flagging rather than guessing:

1. **H3's real fix** — reimplementing the geo math as local-tangent-plane offsets from a reference point (float-friendly, restores AVR accuracy) is an architecture change touching every distance call. The PR ships the honest-docs + `#warning` option instead. Want the tangent-plane version pursued?
2. **H6's real fix** — a placement-new storage pool so `CourseManager` only allocates `courseCount` timers (and could actually release on prune). Doable but invasive; current behavior is now honestly documented. Worth it, or is "CourseManager needs a 256 KB-class MCU" acceptable as policy?
3. **H14 long-term** — standardizing the public API on one speed unit is a breaking change; deferred to a future major version. The shared constants eliminate the drift risk meanwhile.
4. **`peaceiris/actions-gh-pages` v3 → v4** — inputs are compatible and it's the maintained line, but it's a behavior-bearing bump to the docs/badge deploys; watch the first master deploy.
5. The first CI run on this PR will show the new `#warning` in the Mega/Uno compile-examples cells — that's intended signal, not a regression (compile-sketches doesn't fail on warnings).

https://claude.ai/code/session_01XNmVH6ySJ6Dz2QKDjB69mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNmVH6ySJ6Dz2QKDjB69mE)_