### PR TITLE
Cut release 4.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Library version
       description: From the Arduino Library Manager, or the `version=` in library.properties.
-      placeholder: "4.1.0"
+      placeholder: "4.2.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] – 2026-07-17
+
+A hardening release built on the v4.1 test harness. No breaking API changes;
+everything from v4.0/v4.1 keeps working. Fifteen code-review findings across two
+rounds (line-crossing detection at low GPS rates, detection fallbacks, midnight
+rollover, adversarial GPS input, buffer wraparound, precision honesty, and CI
+supply-chain hardening) are fixed, each with a regression test. Adds the public
+getters `getRejectedCrossingCount()`, `isStartFinishLineConfigured()`,
+`CourseDetector::getNoMatchCount()`, and `CourseManager::isCourseTimerActive()`.
+
 ### Fixed
 - **Low-rate GPS silently killed all lap counting** — crossing validation
   required the straddle pair's summed distance to the line to be under
@@ -269,5 +279,6 @@ actually matters.
 For pre-4.0 history (initial sector timing, Catmull-Rom interpolation
 work, etc.) see the git log directly.
 
+[4.2.0]: https://github.com/TheAngryRaven/DovesLapTimer/releases/tag/v4.2.0
 [4.1.0]: https://github.com/TheAngryRaven/DovesLapTimer/releases/tag/v4.1.0
 [4.0.0]: https://github.com/TheAngryRaven/DovesLapTimer/releases/tag/v4.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ In short: tests with changes, changelog updated, docs truthful, no broken window
 
 **What**: GPS-based lap timing Arduino library for go-kart / racing applications.
 **Author**: Michael Champagne (crimsondove)
-**Version**: 4.1.0
+**Version**: 4.2.0
 **Repo**: https://github.com/TheAngryRaven/DovesLapTimer
 **License**: GPL v3
 **Dependency**: ArxTypeTraits (auto-included by Arduino Library Manager)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DovesLapTimer
-version=4.1.0
+version=4.2.0
 author=Michael Champagne (crimsondove)
 maintainer=Michael Champagne
 sentence=GPS-based lap timing library with course detection and multi-course support


### PR DESCRIPTION
## Summary

Release-prep for **4.2.0** on top of the BETA hardening batch. Promotes the
accumulated changes from `[Unreleased]` into a versioned release heading and
bumps the version everywhere it is declared, so BETA → master can then be
merged as a properly-cut release (Arduino Library Manager sees the new version,
and the `v4.2.0` tag lines up with the changelog link + docs/coverage
workflows).

This PR contains no library code changes — only versioning/docs:

- `library.properties`: `version=4.1.0` → `4.2.0`
- `CHANGELOG.md`: `[Unreleased]` entries promoted under `## [4.2.0] – 2026-07-17`
  with a release summary; fresh empty `[Unreleased]`; added the `[4.2.0]`
  version link reference
- `CLAUDE.md`: `**Version**: 4.1.0` → `4.2.0`
- `.github/ISSUE_TEMPLATE/bug_report.yml`: version placeholder `4.1.0` → `4.2.0`

The 4.2.0 batch itself is the fifteen code-review findings already on BETA
(low-rate GPS crossing detection, detection fallbacks, midnight rollover,
adversarial GPS input, buffer wraparound, precision honesty, CI supply-chain
hardening) plus the new public getters `getRejectedCrossingCount()`,
`isStartFinishLineConfigured()`, `CourseDetector::getNoMatchCount()`, and
`CourseManager::isCourseTimerActive()`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Docs / examples
- [x] CI / tooling

## Testing

Full host suite re-run after the edits — 112 tests across 14 binaries, all
green. No code paths touched.

- [x] `cd test && make run` passes locally
- [x] Added/updated tests in the appropriate layer (unit / NMEA replay), or N/A — N/A (versioning only)
- [x] If timing output changed intentionally, updated the pinned goldens **and** explained why below — N/A (no timing change)

## Checklist

- [x] Doc comments updated for any public API changes (feeds the API docs site) — N/A (no API change in this PR)
- [x] `README.md` updated if user-facing behavior changed, or N/A — N/A
- [x] `CHANGELOG.md` updated under "Unreleased", or N/A — entries promoted to `[4.2.0]`
- [x] No new heap allocation in the GPS hot path; SRAM-conscious for AVR targets — N/A (no code change)

## Notes for reviewers

After this merges into BETA and BETA lands on `master`, tag the release:
`git tag v4.2.0 && git push origin v4.2.0`. The `[4.2.0]` changelog link and the
docs/coverage deploy workflows key off that tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULRRhzGC6SkbnhLFxL5vL5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULRRhzGC6SkbnhLFxL5vL5)_